### PR TITLE
Fix reconciliation table column ordering and header styling

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1566,6 +1566,24 @@ pre.sample-value {
     color: #333;
 }
 
+.property-label-help-link {
+    font-weight: 600;
+    color: #333;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.property-label-help-link:hover {
+    color: var(--primary-color);
+    text-decoration: underline;
+}
+
+.property-label-help-link:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 .property-qid-link {
     color: var(--primary-color);
     text-decoration: none;
@@ -1582,6 +1600,23 @@ pre.sample-value {
     outline: 2px solid var(--primary-color);
     outline-offset: 2px;
     border-radius: 2px;
+}
+
+/* Help links for descriptions, labels, etc. */
+.help-link {
+    color: #999;
+    text-decoration: none;
+    margin-left: 8px;
+    font-size: 0.9em;
+    transition: color 0.2s;
+}
+
+.help-link:hover {
+    color: var(--primary-color);
+}
+
+.help-icon {
+    font-weight: bold;
 }
 
 .reconciliation-row:hover {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4682,7 +4682,7 @@ pre.sample-value {
 
 /* Manual property indicators in other steps */
 .manual-property-header {
-    background: linear-gradient(135deg, #e3f2fd 0%, #f3e5f5 100%);
+    /* background: linear-gradient(135deg, #e3f2fd 0%, #f3e5f5 100%); */
 }
 
 .manual-property-cell {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1566,24 +1566,6 @@ pre.sample-value {
     color: #333;
 }
 
-.property-label-help-link {
-    font-weight: 600;
-    color: #333;
-    text-decoration: none;
-    transition: color 0.2s;
-}
-
-.property-label-help-link:hover {
-    color: var(--primary-color);
-    text-decoration: underline;
-}
-
-.property-label-help-link:focus {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 2px;
-    border-radius: 2px;
-}
-
 .property-qid-link {
     color: var(--primary-color);
     text-decoration: none;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1545,6 +1545,45 @@ pre.sample-value {
     min-width: 200px;
 }
 
+/* Clickable property headers */
+.clickable-header {
+    transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.clickable-header:hover {
+    background-color: #e3f2fd !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.property-header-content {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.property-label {
+    font-weight: 600;
+    color: #333;
+}
+
+.property-qid-link {
+    color: var(--primary-color);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s;
+}
+
+.property-qid-link:hover {
+    color: #1976d2;
+    text-decoration: underline;
+}
+
+.property-qid-link:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 .reconciliation-row:hover {
     background-color: #f8f9fa;
 }

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -696,37 +696,10 @@ export function setupState() {
         // Check if property already exists
         const existingIndex = state.mappings.manualProperties.findIndex(p => p.property.id === manualProperty.property.id);
         if (existingIndex === -1) {
-            const newProperty = {
+            state.mappings.manualProperties.push({
                 ...manualProperty,
                 addedAt: new Date().toISOString()
-            };
-            
-            // Priority properties that should be added to the beginning
-            const priorityProperties = ['label', 'description', 'aliases', 'P31'];
-            const isPriorityProperty = priorityProperties.includes(manualProperty.property.id);
-            
-            if (isPriorityProperty) {
-                // Insert at the beginning, but maintain priority order among them
-                const priorityOrder = { 'label': 0, 'description': 1, 'aliases': 2, 'P31': 3 };
-                const currentPriority = priorityOrder[manualProperty.property.id];
-                
-                // Find the correct position to insert based on priority
-                let insertIndex = 0;
-                for (let i = 0; i < state.mappings.manualProperties.length; i++) {
-                    const existingPriority = priorityOrder[state.mappings.manualProperties[i].property.id];
-                    if (existingPriority !== undefined && existingPriority < currentPriority) {
-                        insertIndex = i + 1;
-                    } else {
-                        break;
-                    }
-                }
-                
-                state.mappings.manualProperties.splice(insertIndex, 0, newProperty);
-            } else {
-                // Regular properties go to the end
-                state.mappings.manualProperties.push(newProperty);
-            }
-            
+            });
             state.hasUnsavedChanges = true;
             
             eventSystem.publish(eventSystem.Events.STATE_CHANGED, {
@@ -737,41 +710,6 @@ export function setupState() {
         }
     }
     
-    /**
-     * Sorts existing manual properties to ensure proper priority ordering
-     * Priority: label, description, aliases, instance of, then rest
-     */
-    function sortManualPropertiesByPriority() {
-        ensureMappingArrays();
-        
-        if (state.mappings.manualProperties.length === 0) return;
-        
-        const oldValue = [...state.mappings.manualProperties];
-        const priorityOrder = { 'label': 0, 'description': 1, 'aliases': 2, 'P31': 3 };
-        
-        state.mappings.manualProperties.sort((a, b) => {
-            const aPriority = priorityOrder[a.property.id] ?? 999;
-            const bPriority = priorityOrder[b.property.id] ?? 999;
-            
-            if (aPriority !== bPriority) {
-                return aPriority - bPriority;
-            }
-            
-            // If same priority, maintain original order based on addedAt timestamp
-            const aTime = new Date(a.addedAt || 0).getTime();
-            const bTime = new Date(b.addedAt || 0).getTime();
-            return aTime - bTime;
-        });
-        
-        state.hasUnsavedChanges = true;
-        
-        eventSystem.publish(eventSystem.Events.STATE_CHANGED, {
-            path: 'mappings.manualProperties',
-            oldValue,
-            newValue: [...state.mappings.manualProperties]
-        });
-    }
-
     /**
      * Removes a manual property by property ID
      * @param {String} propertyId - The Wikidata property ID to remove
@@ -860,7 +798,6 @@ export function setupState() {
         ensureMappingArrays,
         addManualProperty,
         removeManualProperty,
-        sortManualPropertiesByPriority,
         // Convenience methods for reconciliation progress
         incrementReconciliationCompleted,
         incrementReconciliationSkipped,

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -696,10 +696,37 @@ export function setupState() {
         // Check if property already exists
         const existingIndex = state.mappings.manualProperties.findIndex(p => p.property.id === manualProperty.property.id);
         if (existingIndex === -1) {
-            state.mappings.manualProperties.push({
+            const newProperty = {
                 ...manualProperty,
                 addedAt: new Date().toISOString()
-            });
+            };
+            
+            // Priority properties that should be added to the beginning
+            const priorityProperties = ['label', 'description', 'aliases', 'P31'];
+            const isPriorityProperty = priorityProperties.includes(manualProperty.property.id);
+            
+            if (isPriorityProperty) {
+                // Insert at the beginning, but maintain priority order among them
+                const priorityOrder = { 'label': 0, 'description': 1, 'aliases': 2, 'P31': 3 };
+                const currentPriority = priorityOrder[manualProperty.property.id];
+                
+                // Find the correct position to insert based on priority
+                let insertIndex = 0;
+                for (let i = 0; i < state.mappings.manualProperties.length; i++) {
+                    const existingPriority = priorityOrder[state.mappings.manualProperties[i].property.id];
+                    if (existingPriority !== undefined && existingPriority < currentPriority) {
+                        insertIndex = i + 1;
+                    } else {
+                        break;
+                    }
+                }
+                
+                state.mappings.manualProperties.splice(insertIndex, 0, newProperty);
+            } else {
+                // Regular properties go to the end
+                state.mappings.manualProperties.push(newProperty);
+            }
+            
             state.hasUnsavedChanges = true;
             
             eventSystem.publish(eventSystem.Events.STATE_CHANGED, {
@@ -710,6 +737,41 @@ export function setupState() {
         }
     }
     
+    /**
+     * Sorts existing manual properties to ensure proper priority ordering
+     * Priority: label, description, aliases, instance of, then rest
+     */
+    function sortManualPropertiesByPriority() {
+        ensureMappingArrays();
+        
+        if (state.mappings.manualProperties.length === 0) return;
+        
+        const oldValue = [...state.mappings.manualProperties];
+        const priorityOrder = { 'label': 0, 'description': 1, 'aliases': 2, 'P31': 3 };
+        
+        state.mappings.manualProperties.sort((a, b) => {
+            const aPriority = priorityOrder[a.property.id] ?? 999;
+            const bPriority = priorityOrder[b.property.id] ?? 999;
+            
+            if (aPriority !== bPriority) {
+                return aPriority - bPriority;
+            }
+            
+            // If same priority, maintain original order based on addedAt timestamp
+            const aTime = new Date(a.addedAt || 0).getTime();
+            const bTime = new Date(b.addedAt || 0).getTime();
+            return aTime - bTime;
+        });
+        
+        state.hasUnsavedChanges = true;
+        
+        eventSystem.publish(eventSystem.Events.STATE_CHANGED, {
+            path: 'mappings.manualProperties',
+            oldValue,
+            newValue: [...state.mappings.manualProperties]
+        });
+    }
+
     /**
      * Removes a manual property by property ID
      * @param {String} propertyId - The Wikidata property ID to remove
@@ -798,6 +860,7 @@ export function setupState() {
         ensureMappingArrays,
         addManualProperty,
         removeManualProperty,
+        sortManualPropertiesByPriority,
         // Convenience methods for reconciliation progress
         incrementReconciliationCompleted,
         incrementReconciliationSkipped,

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -398,9 +398,7 @@ export function setupMappingStep(state) {
         updateSectionCounts(finalState.mappings);
         
         // Auto-add metadata fields and P31 (instance of) in priority order
-        console.log('About to add metadata fields...');
         await autoAddMetadataFieldsInOrder(finalState);
-        console.log('After adding metadata fields, manual properties count:', finalState.mappings.manualProperties.length);
         
         // Auto-open mapped keys section if there are mapped keys
         if (finalState.mappings.mappedKeys.length > 0) {
@@ -430,7 +428,6 @@ export function setupMappingStep(state) {
     
     // Auto-add metadata fields in priority order: Label, Description, Alias, Instance of
     async function autoAddMetadataFieldsInOrder(currentState) {
-        console.log('autoAddMetadataFieldsInOrder called with state:', currentState);
         const priorityFields = [
             {
                 id: 'label',
@@ -460,30 +457,23 @@ export function setupMappingStep(state) {
 
         // Add metadata fields in order
         for (const field of priorityFields) {
-            console.log('Processing field:', field.id);
-            
             // Check if this metadata field is already in manual properties
             const existsInManual = currentState.mappings.manualProperties.some(prop => 
                 prop.property.id === field.id
             );
-            console.log(`${field.id} exists in manual:`, existsInManual);
 
             // Check if this metadata field is already mapped
             const existsInMapped = currentState.mappings.mappedKeys.some(key => 
                 key.property && key.property.id === field.id
             );
-            console.log(`${field.id} exists in mapped:`, existsInMapped);
 
             if (!existsInManual && !existsInMapped) {
-                console.log(`Adding ${field.id} as manual property`);
                 state.addManualProperty({
                     property: field,
                     defaultValue: '',
                     isRequired: field.id === 'label', // Label is required
                     cannotRemove: field.id === 'label' // Label cannot be removed
                 });
-            } else {
-                console.log(`Skipping ${field.id} - already exists`);
             }
         }
 

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -2622,7 +2622,8 @@ export function setupMappingStep(state) {
         
     }
     
-    // Export openMappingModal function globally for use by other modules
+    // Export functions globally for use by other modules
     window.openMappingModal = openMappingModal;
+    window.openManualPropertyEditModal = openManualPropertyEditModal;
     
 }

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -397,9 +397,6 @@ export function setupMappingStep(state) {
         // Update section counts
         updateSectionCounts(finalState.mappings);
         
-        // Ensure proper ordering of existing manual properties
-        state.sortManualPropertiesByPriority();
-        
         // Auto-add metadata fields and P31 (instance of) if not already mapped or present as manual property
         autoAddMetadataFields(finalState);
         autoAddInstanceOfProperty(finalState);

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -397,9 +397,8 @@ export function setupMappingStep(state) {
         // Update section counts
         updateSectionCounts(finalState.mappings);
         
-        // Auto-add metadata fields and P31 (instance of) if not already mapped or present as manual property
-        autoAddMetadataFields(finalState);
-        autoAddInstanceOfProperty(finalState);
+        // Auto-add metadata fields and P31 (instance of) in priority order
+        await autoAddMetadataFieldsInOrder(finalState);
         
         // Auto-open mapped keys section if there are mapped keys
         if (finalState.mappings.mappedKeys.length > 0) {
@@ -427,7 +426,108 @@ export function setupMappingStep(state) {
         }
     }
     
-    // Auto-add metadata fields (label, description, aliases) if not already present
+    // Auto-add metadata fields in priority order: Label, Description, Alias, Instance of
+    async function autoAddMetadataFieldsInOrder(currentState) {
+        const priorityFields = [
+            {
+                id: 'label',
+                label: 'label',
+                description: 'Human-readable name of the item',
+                datatype: 'monolingualtext',
+                datatypeLabel: 'Monolingual text',
+                isMetadata: true
+            },
+            {
+                id: 'description',
+                label: 'description',
+                description: 'Short description of the item',
+                datatype: 'monolingualtext',
+                datatypeLabel: 'Monolingual text',
+                isMetadata: true
+            },
+            {
+                id: 'aliases',
+                label: 'alias', // Changed from 'aliases' to 'alias' for display
+                description: 'Alternative names for the item',
+                datatype: 'monolingualtext',
+                datatypeLabel: 'Monolingual text',
+                isMetadata: true
+            }
+        ];
+
+        // Add metadata fields in order
+        for (const field of priorityFields) {
+            // Check if this metadata field is already in manual properties
+            const existsInManual = currentState.mappings.manualProperties.some(prop => 
+                prop.property.id === field.id
+            );
+
+            // Check if this metadata field is already mapped
+            const existsInMapped = currentState.mappings.mappedKeys.some(key => 
+                key.property && key.property.id === field.id
+            );
+
+            if (!existsInManual && !existsInMapped) {
+                state.addManualProperty({
+                    property: field,
+                    defaultValue: '',
+                    isRequired: field.id === 'label', // Label is required
+                    cannotRemove: field.id === 'label' // Label cannot be removed
+                });
+            }
+        }
+
+        // Add instance of property after the metadata fields
+        await autoAddInstanceOfPropertyAtPosition(currentState);
+
+        // Update section counts after adding all properties
+        if (currentState.mappings.manualProperties.length > 0) {
+            populateLists();
+            updateSectionCounts(state.getState().mappings);
+        }
+    }
+
+    // Auto-add P31 (instance of) at the correct position
+    async function autoAddInstanceOfPropertyAtPosition(currentState) {
+        // Check if P31 or P279 is already mapped
+        const hasP31Mapped = currentState.mappings.mappedKeys.some(key => 
+            key.property && (key.property.id === 'P31' || key.property.id === 'P279')
+        );
+        
+        // Check if P31 or P279 is already in manual properties
+        const hasP31Manual = currentState.mappings.manualProperties.some(prop => 
+            prop.property.id === 'P31' || prop.property.id === 'P279'
+        );
+        
+        // If neither P31 nor P279 is mapped or manual, auto-add P31
+        if (!hasP31Mapped && !hasP31Manual) {
+            try {
+                // Get complete property data for P31
+                const propertyData = await getCompletePropertyData('P31');
+                
+                const p31Property = {
+                    property: {
+                        id: 'P31',
+                        label: 'instance of',
+                        description: 'that class of which this subject is a particular example and member',
+                        datatype: 'wikibase-item',
+                        datatypeLabel: 'Item',
+                        ...propertyData
+                    },
+                    defaultValue: '',
+                    isRequired: true,
+                    cannotRemove: true
+                };
+                
+                state.addManualProperty(p31Property);
+                
+            } catch (error) {
+                console.error('Error adding P31 property:', error);
+            }
+        }
+    }
+
+    // Auto-add metadata fields (label, description, aliases) if not already present - LEGACY FUNCTION
     async function autoAddMetadataFields(currentState) {
         const metadataFields = [
             {

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -2622,4 +2622,7 @@ export function setupMappingStep(state) {
         
     }
     
+    // Export openMappingModal function globally for use by other modules
+    window.openMappingModal = openMappingModal;
+    
 }

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -398,7 +398,9 @@ export function setupMappingStep(state) {
         updateSectionCounts(finalState.mappings);
         
         // Auto-add metadata fields and P31 (instance of) in priority order
+        console.log('About to add metadata fields...');
         await autoAddMetadataFieldsInOrder(finalState);
+        console.log('After adding metadata fields, manual properties count:', finalState.mappings.manualProperties.length);
         
         // Auto-open mapped keys section if there are mapped keys
         if (finalState.mappings.mappedKeys.length > 0) {
@@ -428,6 +430,7 @@ export function setupMappingStep(state) {
     
     // Auto-add metadata fields in priority order: Label, Description, Alias, Instance of
     async function autoAddMetadataFieldsInOrder(currentState) {
+        console.log('autoAddMetadataFieldsInOrder called with state:', currentState);
         const priorityFields = [
             {
                 id: 'label',
@@ -457,23 +460,30 @@ export function setupMappingStep(state) {
 
         // Add metadata fields in order
         for (const field of priorityFields) {
+            console.log('Processing field:', field.id);
+            
             // Check if this metadata field is already in manual properties
             const existsInManual = currentState.mappings.manualProperties.some(prop => 
                 prop.property.id === field.id
             );
+            console.log(`${field.id} exists in manual:`, existsInManual);
 
             // Check if this metadata field is already mapped
             const existsInMapped = currentState.mappings.mappedKeys.some(key => 
                 key.property && key.property.id === field.id
             );
+            console.log(`${field.id} exists in mapped:`, existsInMapped);
 
             if (!existsInManual && !existsInMapped) {
+                console.log(`Adding ${field.id} as manual property`);
                 state.addManualProperty({
                     property: field,
                     defaultValue: '',
                     isRequired: field.id === 'label', // Label is required
                     cannotRemove: field.id === 'label' // Label cannot be removed
                 });
+            } else {
+                console.log(`Skipping ${field.id} - already exists`);
             }
         }
 

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -397,6 +397,9 @@ export function setupMappingStep(state) {
         // Update section counts
         updateSectionCounts(finalState.mappings);
         
+        // Ensure proper ordering of existing manual properties
+        state.sortManualPropertiesByPriority();
+        
         // Auto-add metadata fields and P31 (instance of) if not already mapped or present as manual property
         autoAddMetadataFields(finalState);
         autoAddInstanceOfProperty(finalState);

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -313,9 +313,13 @@ export function setupReconciliationStep(state) {
                         className: 'property-header-content' 
                     });
                     
-                    // Property label
-                    const labelSpan = createElement('span', {
-                        className: 'property-label'
+                    // Property label (clickable link to help page)
+                    const labelSpan = createElement('a', {
+                        className: 'property-label-help-link',
+                        href: 'https://www.wikidata.org/wiki/Help:Label',
+                        target: '_blank',
+                        title: 'Learn about Wikidata labels',
+                        onClick: (e) => e.stopPropagation() // Prevent header click when clicking label
                     }, keyObj.property.label);
                     headerContent.appendChild(labelSpan);
                     
@@ -368,9 +372,13 @@ export function setupReconciliationStep(state) {
                     className: 'property-header-content' 
                 });
                 
-                // Property label
-                const labelSpan = createElement('span', {
-                    className: 'property-label'
+                // Property label (clickable link to help page)
+                const labelSpan = createElement('a', {
+                    className: 'property-label-help-link',
+                    href: 'https://www.wikidata.org/wiki/Help:Label',
+                    target: '_blank',
+                    title: 'Learn about Wikidata labels',
+                    onClick: (e) => e.stopPropagation() // Prevent header click when clicking label
                 }, manualProp.property.label);
                 headerContent.appendChild(labelSpan);
                 
@@ -1156,7 +1164,12 @@ export function setupReconciliationStep(state) {
                             ${propertyInfo.isMock ? ' <span class="mock-indicator">[estimated]</span>' : ''}
                         </a>
                     </div>
-                    <p class="property-description">${propertyInfo.description}</p>
+                    <p class="property-description">
+                        ${propertyInfo.description}
+                        <a href="https://www.wikidata.org/wiki/Help:Description" target="_blank" class="help-link" title="Learn about Wikidata descriptions">
+                            <span class="help-icon">ⓘ</span>
+                        </a>
+                    </p>
                     
                     ${constraintInfo && constraintInfo.hasConstraints ? `
                     <!-- Property Constraints Information -->

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -172,9 +172,8 @@ export function setupReconciliationStep(state) {
                     };
                 });
                 
-                // Initialize each manual property with default values (using same sort order as headers)
-                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
-                sortedManualProperties.forEach(manualProp => {
+                // Initialize each manual property with default values
+                manualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue;
                     
@@ -363,9 +362,8 @@ export function setupReconciliationStep(state) {
                 propertyHeaders.appendChild(th);
             });
             
-            // Add property headers for manual properties with priority ordering
-            const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
-            sortedManualProperties.forEach(manualProp => {
+            // Add property headers for manual properties (now in correct order from source)
+            manualProperties.forEach(manualProp => {
                 // Create header content with property label and clickable QID
                 const headerContent = createElement('div', { 
                     className: 'property-header-content' 
@@ -473,9 +471,8 @@ export function setupReconciliationStep(state) {
                     }
                 });
                 
-                // Add manual property cells (using same sort order as headers)
-                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
-                sortedManualProperties.forEach(manualProp => {
+                // Add manual property cells
+                manualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue || '';
                     
@@ -1398,35 +1395,6 @@ export function setupReconciliationStep(state) {
         
         // For regular properties, use the property page
         return `https://www.wikidata.org/wiki/Property:${property.id}`;
-    }
-    
-    /**
-     * Sort manual properties by priority order: Label, Description, Alias, Instance of, then others
-     */
-    function sortManualPropertiesByPriority(manualProperties) {
-        const priorityOrder = ['label', 'description', 'alias', 'aliases', 'instance of'];
-        
-        return [...manualProperties].sort((a, b) => {
-            const aLabel = a.property.label?.toLowerCase();
-            const bLabel = b.property.label?.toLowerCase();
-            
-            const aIndex = priorityOrder.findIndex(priority => aLabel === priority);
-            const bIndex = priorityOrder.findIndex(priority => bLabel === priority);
-            
-            // If both have priority, sort by priority order
-            if (aIndex !== -1 && bIndex !== -1) {
-                return aIndex - bIndex;
-            }
-            
-            // If only 'a' has priority, it comes first
-            if (aIndex !== -1) return -1;
-            
-            // If only 'b' has priority, it comes first  
-            if (bIndex !== -1) return 1;
-            
-            // If neither has priority, maintain original order (or sort alphabetically)
-            return aLabel?.localeCompare(bLabel) || 0;
-        });
     }
     
     /**

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -325,7 +325,7 @@ export function setupReconciliationStep(state) {
                     // Clickable QID link
                     const qidLink = createElement('a', {
                         className: 'property-qid-link',
-                        href: `https://www.wikidata.org/wiki/${keyObj.property.id}`,
+                        href: `https://www.wikidata.org/wiki/Property:${keyObj.property.id}`,
                         target: '_blank',
                         onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
                     }, keyObj.property.id);
@@ -380,7 +380,7 @@ export function setupReconciliationStep(state) {
                 // Clickable QID link
                 const qidLink = createElement('a', {
                     className: 'property-qid-link',
-                    href: `https://www.wikidata.org/wiki/${manualProp.property.id}`,
+                    href: `https://www.wikidata.org/wiki/Property:${manualProp.property.id}`,
                     target: '_blank',
                     onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
                 }, manualProp.property.id);

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -285,25 +285,51 @@ export function setupReconciliationStep(state) {
     }
     
     /**
-     * Sort mapped keys to prioritize label, description, aliases, and instance of
+     * Combine and sort all properties (mapped and manual) to prioritize label, description, aliases, and instance of
      */
-    function sortMappedKeysForDisplay(mappedKeys) {
-        return [...mappedKeys].sort((a, b) => {
-            const aProperty = typeof a === 'string' ? null : a.property;
-            const bProperty = typeof b === 'string' ? null : b.property;
-            
-            const getPriority = (keyObj) => {
-                const property = typeof keyObj === 'string' ? null : keyObj.property;
-                if (!property) return 100; // Non-property items go to end
+    function combineAndSortProperties(mappedKeys, manualProperties) {
+        // Create a unified array with both mapped and manual properties
+        const allProperties = [];
+        
+        // Add mapped properties with a type indicator
+        mappedKeys.forEach((keyObj, index) => {
+            allProperties.push({
+                type: 'mapped',
+                data: keyObj,
+                originalIndex: index
+            });
+        });
+        
+        // Add manual properties with a type indicator  
+        manualProperties.forEach((manualProp, index) => {
+            allProperties.push({
+                type: 'manual',
+                data: manualProp,
+                originalIndex: index + mappedKeys.length // Offset by mapped keys length
+            });
+        });
+        
+        // Sort the combined array
+        return allProperties.sort((a, b) => {
+            const getPriority = (item) => {
+                let label = '';
+                let id = '';
                 
-                const label = property.label ? property.label.toLowerCase() : '';
-                const id = property.id || '';
+                if (item.type === 'mapped') {
+                    const property = typeof item.data === 'string' ? null : item.data.property;
+                    if (!property) return 100;
+                    label = property.label ? property.label.toLowerCase() : '';
+                    id = property.id || '';
+                } else if (item.type === 'manual') {
+                    label = item.data.property.label ? item.data.property.label.toLowerCase() : '';
+                    id = item.data.property.id || '';
+                }
                 
                 // Priority order: label, description, aliases, instance of (P31), then everything else
                 if (label === 'label') return 1;
                 if (label === 'description') return 2;
                 if (label === 'aliases' || label === 'alias') return 3;
-                if (id === 'P31') return 4; // instance of
+                if (id === 'P31' || label === 'instance of') return 4;
                 
                 return 50; // All other properties maintain relative order
             };
@@ -315,8 +341,8 @@ export function setupReconciliationStep(state) {
                 return aPriority - bPriority;
             }
             
-            // If same priority, maintain original order by finding index in original array
-            return mappedKeys.indexOf(a) - mappedKeys.indexOf(b);
+            // If same priority, maintain original order
+            return a.originalIndex - b.originalIndex;
         });
     }
     
@@ -325,8 +351,8 @@ export function setupReconciliationStep(state) {
      */
     async function createReconciliationTable(data, mappedKeys, manualProperties = [], isReturningToStep = false) {
         
-        // Sort mapped keys for display priority
-        const sortedMappedKeys = sortMappedKeysForDisplay(mappedKeys);
+        // Combine and sort all properties for display priority
+        const sortedProperties = combineAndSortProperties(mappedKeys, manualProperties);
         
         // Clear existing content
         if (propertyHeaders) {
@@ -338,123 +364,127 @@ export function setupReconciliationStep(state) {
             }, 'Item');
             propertyHeaders.appendChild(itemHeader);
             
-            // Add property headers for mapped keys (using sorted order)
-            sortedMappedKeys.forEach(keyObj => {
-                const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
-                
-                // Create header content with property label and clickable QID
-                let headerContent;
-                let clickHandler = null;
-                
-                if (keyObj.property && keyObj.property.label && keyObj.property.id) {
-                    // Create header with property label and clickable QID
-                    headerContent = createElement('div', { 
+            // Add property headers for all properties in sorted order
+            sortedProperties.forEach(propItem => {
+                if (propItem.type === 'mapped') {
+                    // Handle mapped property
+                    const keyObj = propItem.data;
+                    const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
+                    
+                    // Create header content with property label and clickable QID
+                    let headerContent;
+                    let clickHandler = null;
+                    
+                    if (keyObj.property && keyObj.property.label && keyObj.property.id) {
+                        // Create header with property label and clickable QID
+                        headerContent = createElement('div', { 
+                            className: 'property-header-content' 
+                        });
+                        
+                        // Property label (clickable span - will be handled by header click)
+                        const labelSpan = createElement('span', {
+                            className: 'property-label'
+                        }, keyObj.property.label);
+                        headerContent.appendChild(labelSpan);
+                        
+                        // Space and opening bracket
+                        headerContent.appendChild(document.createTextNode(' ('));
+                        
+                        // Clickable QID link - smart routing based on property type
+                        const wikidataUrl = getWikidataUrlForProperty(keyObj.property);
+                        const qidLink = createElement('a', {
+                            className: 'property-qid-link',
+                            href: wikidataUrl,
+                            target: '_blank',
+                            onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
+                        }, keyObj.property.id);
+                        headerContent.appendChild(qidLink);
+                        
+                        // Closing bracket
+                        headerContent.appendChild(document.createTextNode(')'));
+                        
+                        // Set click handler to open mapping modal
+                        clickHandler = () => {
+                            if (window.openMappingModal) {
+                                window.openMappingModal(keyObj);
+                            }
+                        };
+                    } else {
+                        // Fallback to original key name if no property info available
+                        headerContent = keyName;
+                        clickHandler = () => {
+                            if (window.openMappingModal) {
+                                window.openMappingModal(keyObj);
+                            }
+                        };
+                    }
+                    
+                    const th = createElement('th', {
+                        className: 'property-header clickable-header',
+                        dataset: { property: keyName },
+                        onClick: clickHandler,
+                        style: { cursor: 'pointer' },
+                        title: 'Click to modify mapping'
+                    }, headerContent);
+                    
+                    propertyHeaders.appendChild(th);
+                } else if (propItem.type === 'manual') {
+                    // Handle manual property
+                    const manualProp = propItem.data;
+                    
+                    // Create header content with property label and clickable QID
+                    const headerContent = createElement('div', { 
                         className: 'property-header-content' 
                     });
                     
                     // Property label (clickable span - will be handled by header click)
                     const labelSpan = createElement('span', {
                         className: 'property-label'
-                    }, keyObj.property.label);
+                    }, manualProp.property.label);
                     headerContent.appendChild(labelSpan);
                     
                     // Space and opening bracket
                     headerContent.appendChild(document.createTextNode(' ('));
                     
                     // Clickable QID link - smart routing based on property type
-                    const wikidataUrl = getWikidataUrlForProperty(keyObj.property);
+                    const wikidataUrl = getWikidataUrlForProperty(manualProp.property);
                     const qidLink = createElement('a', {
                         className: 'property-qid-link',
                         href: wikidataUrl,
                         target: '_blank',
                         onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
-                    }, keyObj.property.id);
+                    }, manualProp.property.id);
                     headerContent.appendChild(qidLink);
                     
                     // Closing bracket
                     headerContent.appendChild(document.createTextNode(')'));
                     
-                    // Set click handler to open mapping modal
-                    clickHandler = () => {
-                        if (window.openMappingModal) {
-                            window.openMappingModal(keyObj);
-                        }
-                    };
-                } else {
-                    // Fallback to original key name if no property info available
-                    headerContent = keyName;
-                    clickHandler = () => {
-                        if (window.openMappingModal) {
-                            window.openMappingModal(keyObj);
-                        }
-                    };
+                    // Add required indicator if applicable
+                    if (manualProp.isRequired) {
+                        const requiredIndicator = createElement('span', {
+                            className: 'required-indicator-header'
+                        }, ' *');
+                        headerContent.appendChild(requiredIndicator);
+                    }
+                    
+                    const th = createElement('th', {
+                        className: 'property-header manual-property-header clickable-header',
+                        dataset: { 
+                            property: manualProp.property.id,
+                            isManual: 'true'
+                        },
+                        title: `${manualProp.property.description}\nClick to modify property settings`,
+                        onClick: () => {
+                            // Open the manual property edit modal
+                            if (window.openManualPropertyEditModal) {
+                                window.openManualPropertyEditModal(manualProp);
+                            }
+                        },
+                        style: { cursor: 'pointer' }
+                    }, headerContent);
+                    
+                    propertyHeaders.appendChild(th);
                 }
-                
-                const th = createElement('th', {
-                    className: 'property-header clickable-header',
-                    dataset: { property: keyName },
-                    onClick: clickHandler,
-                    style: { cursor: 'pointer' },
-                    title: 'Click to modify mapping'
-                }, headerContent);
-                
-                propertyHeaders.appendChild(th);
-            });
-            
-            // Add property headers for manual properties
-            manualProperties.forEach(manualProp => {
-                // Create header content with property label and clickable QID
-                const headerContent = createElement('div', { 
-                    className: 'property-header-content' 
-                });
-                
-                // Property label (clickable span - will be handled by header click)
-                const labelSpan = createElement('span', {
-                    className: 'property-label'
-                }, manualProp.property.label);
-                headerContent.appendChild(labelSpan);
-                
-                // Space and opening bracket
-                headerContent.appendChild(document.createTextNode(' ('));
-                
-                // Clickable QID link - smart routing based on property type
-                const wikidataUrl = getWikidataUrlForProperty(manualProp.property);
-                const qidLink = createElement('a', {
-                    className: 'property-qid-link',
-                    href: wikidataUrl,
-                    target: '_blank',
-                    onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
-                }, manualProp.property.id);
-                headerContent.appendChild(qidLink);
-                
-                // Closing bracket
-                headerContent.appendChild(document.createTextNode(')'));
-                
-                // Add required indicator if applicable
-                if (manualProp.isRequired) {
-                    const requiredIndicator = createElement('span', {
-                        className: 'required-indicator-header'
-                    }, ' *');
-                    headerContent.appendChild(requiredIndicator);
-                }
-                
-                const th = createElement('th', {
-                    className: 'property-header manual-property-header clickable-header',
-                    dataset: { 
-                        property: manualProp.property.id,
-                        isManual: 'true'
-                    },
-                    title: `${manualProp.property.description}\nClick to modify property settings`,
-                    onClick: () => {
-                        // Open the manual property edit modal
-                        if (window.openManualPropertyEditModal) {
-                            window.openManualPropertyEditModal(manualProp);
-                        }
-                    },
-                    style: { cursor: 'pointer' }
-                }, headerContent);
-                
-                propertyHeaders.appendChild(th);
             });
         }
         
@@ -477,47 +507,50 @@ export function setupReconciliationStep(state) {
                 tr.appendChild(itemCell);
                 
                 // Add property cells (using sorted order to match headers)
-                sortedMappedKeys.forEach(keyObj => {
-                    const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
-                    const values = extractPropertyValues(item, keyName);
-                    
-                    if (values.length === 0) {
-                        // Empty cell
-                        const td = createElement('td', {
-                            className: 'property-cell empty-cell'
-                        }, '—');
-                        tr.appendChild(td);
-                    } else if (values.length === 1) {
-                        // Single value cell
-                        const td = createPropertyCell(itemId, keyName, 0, values[0]);
-                        tr.appendChild(td);
-                    } else {
-                        // Multiple values cell
-                        const td = createElement('td', {
-                            className: 'property-cell multi-value-cell',
-                            dataset: {
-                                itemId: itemId,
-                                property: keyName
-                            }
-                        });
+                sortedProperties.forEach(propItem => {
+                    if (propItem.type === 'mapped') {
+                        // Handle mapped property cell
+                        const keyObj = propItem.data;
+                        const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
+                        const values = extractPropertyValues(item, keyName);
                         
-                        values.forEach((value, valueIndex) => {
-                            const valueDiv = createValueElement(itemId, keyName, valueIndex, value);
-                            td.appendChild(valueDiv);
-                        });
+                        if (values.length === 0) {
+                            // Empty cell
+                            const td = createElement('td', {
+                                className: 'property-cell empty-cell'
+                            }, '—');
+                            tr.appendChild(td);
+                        } else if (values.length === 1) {
+                            // Single value cell
+                            const td = createPropertyCell(itemId, keyName, 0, values[0]);
+                            tr.appendChild(td);
+                        } else {
+                            // Multiple values cell
+                            const td = createElement('td', {
+                                className: 'property-cell multi-value-cell',
+                                dataset: {
+                                    itemId: itemId,
+                                    property: keyName
+                                }
+                            });
+                            
+                            values.forEach((value, valueIndex) => {
+                                const valueDiv = createValueElement(itemId, keyName, valueIndex, value);
+                                td.appendChild(valueDiv);
+                            });
+                            
+                            tr.appendChild(td);
+                        }
+                    } else if (propItem.type === 'manual') {
+                        // Handle manual property cell
+                        const manualProp = propItem.data;
+                        const propertyId = manualProp.property.id;
+                        const defaultValue = manualProp.defaultValue || '';
                         
+                        // Create a cell for the manual property with the default value
+                        const td = createManualPropertyCell(itemId, propertyId, defaultValue, manualProp);
                         tr.appendChild(td);
                     }
-                });
-                
-                // Add manual property cells
-                manualProperties.forEach(manualProp => {
-                    const propertyId = manualProp.property.id;
-                    const defaultValue = manualProp.defaultValue || '';
-                    
-                    // Create a cell for the manual property with the default value
-                    const td = createManualPropertyCell(itemId, propertyId, defaultValue, manualProp);
-                    tr.appendChild(td);
                 });
                 
                 reconciliationRows.appendChild(tr);

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -172,9 +172,8 @@ export function setupReconciliationStep(state) {
                     };
                 });
                 
-                // Initialize each manual property with default values (using same sort order as headers)
-                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
-                sortedManualProperties.forEach(manualProp => {
+                // Initialize each manual property with default values
+                manualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue;
                     
@@ -363,9 +362,8 @@ export function setupReconciliationStep(state) {
                 propertyHeaders.appendChild(th);
             });
             
-            // Add property headers for manual properties with priority ordering
-            const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
-            sortedManualProperties.forEach(manualProp => {
+            // Add property headers for manual properties
+            manualProperties.forEach(manualProp => {
                 // Create header content with property label and clickable QID
                 const headerContent = createElement('div', { 
                     className: 'property-header-content' 
@@ -473,9 +471,8 @@ export function setupReconciliationStep(state) {
                     }
                 });
                 
-                // Add manual property cells (using same sort order as headers)
-                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
-                sortedManualProperties.forEach(manualProp => {
+                // Add manual property cells
+                manualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue || '';
                     
@@ -1398,35 +1395,6 @@ export function setupReconciliationStep(state) {
         
         // For regular properties, use the property page
         return `https://www.wikidata.org/wiki/Property:${property.id}`;
-    }
-    
-    /**
-     * Sort manual properties by priority order: Label, Description, Alias, Instance of, then others
-     */
-    function sortManualPropertiesByPriority(manualProperties) {
-        const priorityOrder = ['label', 'description', 'alias', 'aliases', 'instance of'];
-        
-        return [...manualProperties].sort((a, b) => {
-            const aLabel = a.property.label?.toLowerCase();
-            const bLabel = b.property.label?.toLowerCase();
-            
-            const aIndex = priorityOrder.findIndex(priority => aLabel === priority);
-            const bIndex = priorityOrder.findIndex(priority => bLabel === priority);
-            
-            // If both have priority, sort by priority order
-            if (aIndex !== -1 && bIndex !== -1) {
-                return aIndex - bIndex;
-            }
-            
-            // If only 'a' has priority, it comes first
-            if (aIndex !== -1) return -1;
-            
-            // If only 'b' has priority, it comes first  
-            if (bIndex !== -1) return 1;
-            
-            // If neither has priority, maintain original order (or sort alphabetically)
-            return aLabel?.localeCompare(bLabel) || 0;
-        });
     }
     
     /**

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -407,11 +407,10 @@ export function setupReconciliationStep(state) {
                     },
                     title: `${manualProp.property.description}\nClick to modify property settings`,
                     onClick: () => {
-                        // For manual properties, we could open the manual property edit modal
-                        // But since it's not immediately clear how to create the keyObj for manual properties,
-                        // let's just add a message for now indicating this functionality
-                        console.log('Manual property header clicked:', manualProp);
-                        // TODO: Implement manual property editing via modal
+                        // Open the manual property edit modal
+                        if (window.openManualPropertyEditModal) {
+                            window.openManualPropertyEditModal(manualProp);
+                        }
                     },
                     style: { cursor: 'pointer' }
                 }, headerContent);

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -11,53 +11,6 @@ import { eventSystem } from '../events.js';
 import { getMockItemsData, getMockMappingData } from '../data/mock-data.js';
 import { createElement } from '../ui/components.js';
 
-/**
- * Sort properties/keys by priority for column ordering
- * Priority: label, description, aliases, instance of, then maintain original order
- */
-function sortColumnsByPriority(items) {
-    const priorityOrder = {
-        // Label properties
-        'label': 1,
-        'P1476': 1, // title
-        'rdfs:label': 1,
-        'schema:name': 1,
-        'dcterms:title': 1,
-        'foaf:name': 1,
-        
-        // Description properties  
-        'description': 2,
-        'schema:description': 2,
-        'dcterms:description': 2,
-        'P1813': 2, // short name
-        
-        // Aliases properties
-        'aliases': 3,
-        'P1449': 3, // nickname
-        'P2561': 3, // name
-        'skos:altLabel': 3,
-        
-        // Instance of
-        'P31': 4 // instance of
-    };
-    
-    return items.sort((a, b) => {
-        // Get property ID for both items
-        const aId = (a.property && a.property.id) || a.key || a;
-        const bId = (b.property && b.property.id) || b.key || b;
-        
-        const aPriority = priorityOrder[aId] || 999;
-        const bPriority = priorityOrder[bId] || 999;
-        
-        if (aPriority !== bPriority) {
-            return aPriority - bPriority;
-        }
-        
-        // If same priority, maintain original order
-        return 0;
-    });
-}
-
 export function setupReconciliationStep(state) {
     
     // Initialize modal UI
@@ -336,22 +289,6 @@ export function setupReconciliationStep(state) {
      */
     async function createReconciliationTable(data, mappedKeys, manualProperties = [], isReturningToStep = false) {
         
-        // Sort columns to prioritize: label, description, aliases, instance of, then default order
-        const sortedMappedKeys = sortColumnsByPriority([...mappedKeys]);
-        const sortedManualProperties = sortColumnsByPriority([...manualProperties]);
-        
-        // Debug: Log column ordering
-        console.log('📊 Reconciliation table column order:', [
-            ...sortedMappedKeys.map(key => {
-                const id = (key.property && key.property.id) || key.key || key;
-                const label = (key.property && key.property.label) || 'Unknown';
-                return `${label} (${id})`;
-            }),
-            ...sortedManualProperties.map(prop => {
-                return `${prop.property.label} (${prop.property.id})`;
-            })
-        ]);
-        
         // Clear existing content
         if (propertyHeaders) {
             propertyHeaders.innerHTML = '';
@@ -363,7 +300,7 @@ export function setupReconciliationStep(state) {
             propertyHeaders.appendChild(itemHeader);
             
             // Add property headers for mapped keys
-            sortedMappedKeys.forEach(keyObj => {
+            mappedKeys.forEach(keyObj => {
                 const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
                 
                 // Create header content with property label and clickable QID
@@ -426,7 +363,7 @@ export function setupReconciliationStep(state) {
             });
             
             // Add property headers for manual properties
-            sortedManualProperties.forEach(manualProp => {
+            manualProperties.forEach(manualProp => {
                 // Create header content with property label and clickable QID
                 const headerContent = createElement('div', { 
                     className: 'property-header-content' 
@@ -501,7 +438,7 @@ export function setupReconciliationStep(state) {
                 tr.appendChild(itemCell);
                 
                 // Add property cells
-                sortedMappedKeys.forEach(keyObj => {
+                mappedKeys.forEach(keyObj => {
                     const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
                     const values = extractPropertyValues(item, keyName);
                     
@@ -535,7 +472,7 @@ export function setupReconciliationStep(state) {
                 });
                 
                 // Add manual property cells
-                sortedManualProperties.forEach(manualProp => {
+                manualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue || '';
                     
@@ -549,9 +486,9 @@ export function setupReconciliationStep(state) {
             
             // Only perform batch auto-acceptance for fresh initialization, not when returning to step
             if (!isReturningToStep) {
-                await performBatchAutoAcceptance(data, sortedMappedKeys, sortedManualProperties);
+                await performBatchAutoAcceptance(data, mappedKeys, manualProperties);
             } else {
-                restoreReconciliationDisplay(data, sortedMappedKeys, sortedManualProperties);
+                restoreReconciliationDisplay(data, mappedKeys, manualProperties);
             }
             
         } else {

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -11,50 +11,6 @@ import { eventSystem } from '../events.js';
 import { getMockItemsData, getMockMappingData } from '../data/mock-data.js';
 import { createElement } from '../ui/components.js';
 
-/**
- * Sort properties with priority ordering: label, description, aliases, instance of, then rest
- * @param {Array} mappedKeys - Array of mapped key objects
- * @returns {Array} Sorted array with priority properties first
- */
-function sortPropertiesByPriority(mappedKeys) {
-    const priorityOrder = {
-        // Label properties (priority 1)
-        'P1476': 1, // title
-        'rdfs:label': 1, // rdfs label
-        'schema:name': 1, // schema.org name
-        'dcterms:title': 1, // Dublin Core title
-        'foaf:name': 1, // FOAF name
-        
-        // Description properties (priority 2) 
-        'schema:description': 2, // schema.org description
-        'dcterms:description': 2, // Dublin Core description
-        'P1813': 2, // short name
-        
-        // Aliases properties (priority 3)
-        'P1449': 3, // nickname
-        'P2561': 3, // name
-        'skos:altLabel': 3, // alternative label
-        
-        // Instance of (priority 4)
-        'P31': 4   // instance of
-    };
-    
-    return mappedKeys.sort((a, b) => {
-        const aId = (a.property && a.property.id) || a.key || a;
-        const bId = (b.property && b.property.id) || b.key || b;
-        
-        const aPriority = priorityOrder[aId] || 999;
-        const bPriority = priorityOrder[bId] || 999;
-        
-        if (aPriority !== bPriority) {
-            return aPriority - bPriority;
-        }
-        
-        // If same priority, maintain original order
-        return 0;
-    });
-}
-
 export function setupReconciliationStep(state) {
     
     // Initialize modal UI
@@ -170,17 +126,7 @@ export function setupReconciliationStep(state) {
         
         
         // Filter out keys that are not in the current dataset
-        const filteredMappedKeys = currentState.mappings.mappedKeys.filter(keyObj => !keyObj.notInCurrentDataset);
-        
-        // Sort mappedKeys with priority order: label, description, aliases, instance of, then rest
-        const mappedKeys = sortPropertiesByPriority(filteredMappedKeys);
-        
-        // Log the sorted order for debugging
-        console.log('📊 Column ordering applied:', mappedKeys.map(key => {
-            const id = (key.property && key.property.id) || key.key || key;
-            const label = (key.property && key.property.label) || 'Unknown';
-            return `${label} (${id})`;
-        }));
+        const mappedKeys = currentState.mappings.mappedKeys.filter(keyObj => !keyObj.notInCurrentDataset);
         
         // Get manual properties
         const manualProperties = currentState.mappings.manualProperties || [];

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -313,23 +313,20 @@ export function setupReconciliationStep(state) {
                         className: 'property-header-content' 
                     });
                     
-                    // Property label (clickable link to help page)
-                    const labelSpan = createElement('a', {
-                        className: 'property-label-help-link',
-                        href: 'https://www.wikidata.org/wiki/Help:Label',
-                        target: '_blank',
-                        title: 'Learn about Wikidata labels',
-                        onClick: (e) => e.stopPropagation() // Prevent header click when clicking label
+                    // Property label (clickable span - will be handled by header click)
+                    const labelSpan = createElement('span', {
+                        className: 'property-label'
                     }, keyObj.property.label);
                     headerContent.appendChild(labelSpan);
                     
                     // Space and opening bracket
                     headerContent.appendChild(document.createTextNode(' ('));
                     
-                    // Clickable QID link
+                    // Clickable QID link - smart routing based on property type
+                    const wikidataUrl = getWikidataUrlForProperty(keyObj.property);
                     const qidLink = createElement('a', {
                         className: 'property-qid-link',
-                        href: `https://www.wikidata.org/wiki/Property:${keyObj.property.id}`,
+                        href: wikidataUrl,
                         target: '_blank',
                         onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
                     }, keyObj.property.id);
@@ -372,23 +369,20 @@ export function setupReconciliationStep(state) {
                     className: 'property-header-content' 
                 });
                 
-                // Property label (clickable link to help page)
-                const labelSpan = createElement('a', {
-                    className: 'property-label-help-link',
-                    href: 'https://www.wikidata.org/wiki/Help:Label',
-                    target: '_blank',
-                    title: 'Learn about Wikidata labels',
-                    onClick: (e) => e.stopPropagation() // Prevent header click when clicking label
+                // Property label (clickable span - will be handled by header click)
+                const labelSpan = createElement('span', {
+                    className: 'property-label'
                 }, manualProp.property.label);
                 headerContent.appendChild(labelSpan);
                 
                 // Space and opening bracket
                 headerContent.appendChild(document.createTextNode(' ('));
                 
-                // Clickable QID link
+                // Clickable QID link - smart routing based on property type
+                const wikidataUrl = getWikidataUrlForProperty(manualProp.property);
                 const qidLink = createElement('a', {
                     className: 'property-qid-link',
-                    href: `https://www.wikidata.org/wiki/Property:${manualProp.property.id}`,
+                    href: wikidataUrl,
                     target: '_blank',
                     onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
                 }, manualProp.property.id);
@@ -1381,6 +1375,27 @@ export function setupReconciliationStep(state) {
         }
         
         return `Property describing ${property.replace(/[_-]/g, ' ')}`;
+    }
+    
+    /**
+     * Get the correct Wikidata URL for a property based on its type
+     */
+    function getWikidataUrlForProperty(property) {
+        const label = property.label?.toLowerCase();
+        
+        // Special cases for core Wikidata concepts
+        if (label === 'label') {
+            return 'https://www.wikidata.org/wiki/Help:Label';
+        }
+        if (label === 'description') {
+            return 'https://www.wikidata.org/wiki/Help:Description';
+        }
+        if (label === 'aliases' || label === 'alias') {
+            return 'https://www.wikidata.org/wiki/Help:Aliases';
+        }
+        
+        // For regular properties, use the property page
+        return `https://www.wikidata.org/wiki/Property:${property.id}`;
     }
     
     /**

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -172,8 +172,9 @@ export function setupReconciliationStep(state) {
                     };
                 });
                 
-                // Initialize each manual property with default values
-                manualProperties.forEach(manualProp => {
+                // Initialize each manual property with default values (using same sort order as headers)
+                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
+                sortedManualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue;
                     
@@ -362,8 +363,9 @@ export function setupReconciliationStep(state) {
                 propertyHeaders.appendChild(th);
             });
             
-            // Add property headers for manual properties (now in correct order from source)
-            manualProperties.forEach(manualProp => {
+            // Add property headers for manual properties with priority ordering
+            const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
+            sortedManualProperties.forEach(manualProp => {
                 // Create header content with property label and clickable QID
                 const headerContent = createElement('div', { 
                     className: 'property-header-content' 
@@ -471,8 +473,9 @@ export function setupReconciliationStep(state) {
                     }
                 });
                 
-                // Add manual property cells
-                manualProperties.forEach(manualProp => {
+                // Add manual property cells (using same sort order as headers)
+                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
+                sortedManualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue || '';
                     
@@ -1395,6 +1398,35 @@ export function setupReconciliationStep(state) {
         
         // For regular properties, use the property page
         return `https://www.wikidata.org/wiki/Property:${property.id}`;
+    }
+    
+    /**
+     * Sort manual properties by priority order: Label, Description, Alias, Instance of, then others
+     */
+    function sortManualPropertiesByPriority(manualProperties) {
+        const priorityOrder = ['label', 'description', 'alias', 'aliases', 'instance of'];
+        
+        return [...manualProperties].sort((a, b) => {
+            const aLabel = a.property.label?.toLowerCase();
+            const bLabel = b.property.label?.toLowerCase();
+            
+            const aIndex = priorityOrder.findIndex(priority => aLabel === priority);
+            const bIndex = priorityOrder.findIndex(priority => bLabel === priority);
+            
+            // If both have priority, sort by priority order
+            if (aIndex !== -1 && bIndex !== -1) {
+                return aIndex - bIndex;
+            }
+            
+            // If only 'a' has priority, it comes first
+            if (aIndex !== -1) return -1;
+            
+            // If only 'b' has priority, it comes first  
+            if (bIndex !== -1) return 1;
+            
+            // If neither has priority, maintain original order (or sort alphabetically)
+            return aLabel?.localeCompare(bLabel) || 0;
+        });
     }
     
     /**

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -172,8 +172,9 @@ export function setupReconciliationStep(state) {
                     };
                 });
                 
-                // Initialize each manual property with default values
-                manualProperties.forEach(manualProp => {
+                // Initialize each manual property with default values (using same sort order as headers)
+                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
+                sortedManualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue;
                     
@@ -362,8 +363,9 @@ export function setupReconciliationStep(state) {
                 propertyHeaders.appendChild(th);
             });
             
-            // Add property headers for manual properties
-            manualProperties.forEach(manualProp => {
+            // Add property headers for manual properties with priority ordering
+            const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
+            sortedManualProperties.forEach(manualProp => {
                 // Create header content with property label and clickable QID
                 const headerContent = createElement('div', { 
                     className: 'property-header-content' 
@@ -471,8 +473,9 @@ export function setupReconciliationStep(state) {
                     }
                 });
                 
-                // Add manual property cells
-                manualProperties.forEach(manualProp => {
+                // Add manual property cells (using same sort order as headers)
+                const sortedManualProperties = sortManualPropertiesByPriority(manualProperties);
+                sortedManualProperties.forEach(manualProp => {
                     const propertyId = manualProp.property.id;
                     const defaultValue = manualProp.defaultValue || '';
                     
@@ -1395,6 +1398,35 @@ export function setupReconciliationStep(state) {
         
         // For regular properties, use the property page
         return `https://www.wikidata.org/wiki/Property:${property.id}`;
+    }
+    
+    /**
+     * Sort manual properties by priority order: Label, Description, Alias, Instance of, then others
+     */
+    function sortManualPropertiesByPriority(manualProperties) {
+        const priorityOrder = ['label', 'description', 'alias', 'aliases', 'instance of'];
+        
+        return [...manualProperties].sort((a, b) => {
+            const aLabel = a.property.label?.toLowerCase();
+            const bLabel = b.property.label?.toLowerCase();
+            
+            const aIndex = priorityOrder.findIndex(priority => aLabel === priority);
+            const bIndex = priorityOrder.findIndex(priority => bLabel === priority);
+            
+            // If both have priority, sort by priority order
+            if (aIndex !== -1 && bIndex !== -1) {
+                return aIndex - bIndex;
+            }
+            
+            // If only 'a' has priority, it comes first
+            if (aIndex !== -1) return -1;
+            
+            // If only 'b' has priority, it comes first  
+            if (bIndex !== -1) return 1;
+            
+            // If neither has priority, maintain original order (or sort alphabetically)
+            return aLabel?.localeCompare(bLabel) || 0;
+        });
     }
     
     /**

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -302,32 +302,117 @@ export function setupReconciliationStep(state) {
             // Add property headers for mapped keys
             mappedKeys.forEach(keyObj => {
                 const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
+                
+                // Create header content with property label and clickable QID
+                let headerContent;
+                let clickHandler = null;
+                
+                if (keyObj.property && keyObj.property.label && keyObj.property.id) {
+                    // Create header with property label and clickable QID
+                    headerContent = createElement('div', { 
+                        className: 'property-header-content' 
+                    });
+                    
+                    // Property label
+                    const labelSpan = createElement('span', {
+                        className: 'property-label'
+                    }, keyObj.property.label);
+                    headerContent.appendChild(labelSpan);
+                    
+                    // Space and opening bracket
+                    headerContent.appendChild(document.createTextNode(' ('));
+                    
+                    // Clickable QID link
+                    const qidLink = createElement('a', {
+                        className: 'property-qid-link',
+                        href: `https://www.wikidata.org/wiki/${keyObj.property.id}`,
+                        target: '_blank',
+                        onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
+                    }, keyObj.property.id);
+                    headerContent.appendChild(qidLink);
+                    
+                    // Closing bracket
+                    headerContent.appendChild(document.createTextNode(')'));
+                    
+                    // Set click handler to open mapping modal
+                    clickHandler = () => {
+                        if (window.openMappingModal) {
+                            window.openMappingModal(keyObj);
+                        }
+                    };
+                } else {
+                    // Fallback to original key name if no property info available
+                    headerContent = keyName;
+                    clickHandler = () => {
+                        if (window.openMappingModal) {
+                            window.openMappingModal(keyObj);
+                        }
+                    };
+                }
+                
                 const th = createElement('th', {
-                    className: 'property-header',
-                    dataset: { property: keyName }
-                }, keyName);
+                    className: 'property-header clickable-header',
+                    dataset: { property: keyName },
+                    onClick: clickHandler,
+                    style: { cursor: 'pointer' },
+                    title: 'Click to modify mapping'
+                }, headerContent);
+                
                 propertyHeaders.appendChild(th);
             });
             
             // Add property headers for manual properties
             manualProperties.forEach(manualProp => {
-                const propertyLabel = `${manualProp.property.label} (${manualProp.property.id})`;
-                const th = createElement('th', {
-                    className: 'property-header manual-property-header',
-                    dataset: { 
-                        property: manualProp.property.id,
-                        isManual: 'true'
-                    },
-                    title: manualProp.property.description
-                }, propertyLabel);
+                // Create header content with property label and clickable QID
+                const headerContent = createElement('div', { 
+                    className: 'property-header-content' 
+                });
+                
+                // Property label
+                const labelSpan = createElement('span', {
+                    className: 'property-label'
+                }, manualProp.property.label);
+                headerContent.appendChild(labelSpan);
+                
+                // Space and opening bracket
+                headerContent.appendChild(document.createTextNode(' ('));
+                
+                // Clickable QID link
+                const qidLink = createElement('a', {
+                    className: 'property-qid-link',
+                    href: `https://www.wikidata.org/wiki/${manualProp.property.id}`,
+                    target: '_blank',
+                    onClick: (e) => e.stopPropagation() // Prevent header click when clicking QID
+                }, manualProp.property.id);
+                headerContent.appendChild(qidLink);
+                
+                // Closing bracket
+                headerContent.appendChild(document.createTextNode(')'));
                 
                 // Add required indicator if applicable
                 if (manualProp.isRequired) {
                     const requiredIndicator = createElement('span', {
                         className: 'required-indicator-header'
                     }, ' *');
-                    th.appendChild(requiredIndicator);
+                    headerContent.appendChild(requiredIndicator);
                 }
+                
+                const th = createElement('th', {
+                    className: 'property-header manual-property-header clickable-header',
+                    dataset: { 
+                        property: manualProp.property.id,
+                        isManual: 'true'
+                    },
+                    title: `${manualProp.property.description}\nClick to modify property settings`,
+                    onClick: () => {
+                        // For manual properties, we could open the manual property edit modal
+                        // But since it's not immediately clear how to create the keyObj for manual properties,
+                        // let's just add a message for now indicating this functionality
+                        console.log('Manual property header clicked:', manualProp);
+                        // TODO: Implement manual property editing via modal
+                    },
+                    style: { cursor: 'pointer' }
+                }, headerContent);
                 
                 propertyHeaders.appendChild(th);
             });


### PR DESCRIPTION
## Summary
- Fixed reconciliation table column ordering to prioritize metadata fields (label, description, aliases, instance of) before other properties
- Removed background color gradient from manual property headers for cleaner appearance
- Combined handling of both mapped and manual properties to ensure consistent ordering

## Changes
1. **Column Ordering Fix**: Created `combineAndSortProperties()` function that merges mapped and manual properties and sorts them with priority:
   - Label (priority 1)
   - Description (priority 2)
   - Aliases (priority 3)
   - Instance of/P31 (priority 4)
   - All other properties maintain their original order

2. **Unified Property Handling**: Updated table rendering to handle both mapped and manual properties in a single loop, ensuring headers and data cells are properly aligned

3. **Header Styling**: Removed the gradient background from manual property headers (`.manual-property-header`) for a cleaner, more uniform table appearance

## Test plan
- [ ] Load a project with both mapped properties and manual properties (label, description, aliases, instance of)
- [ ] Verify that the reconciliation table shows columns in the correct order: label, description, aliases, instance of, then other properties
- [ ] Verify that manual property headers no longer have the blue-purple gradient background
- [ ] Test that all property headers remain clickable and functional
- [ ] Ensure data cells align correctly with their headers

🤖 Generated with [Claude Code](https://claude.ai/code)