### PR TITLE
Fix syntax error in constraint-helpers.js JSDoc comment

### DIFF
--- a/src/js/utils/constraint-helpers.js
+++ b/src/js/utils/constraint-helpers.js
@@ -227,6 +227,7 @@ export function validateAgainstFormatConstraints(value, propertyObj) {
  * 5. Normalizes final score to 0-100 range
  * 6. Logs scoring details for debugging and quality assurance
  */
+ /**
  * @param {string} originalValue - Original value being reconciled
  * @returns {Object} Enhanced match with constraint-based scoring
  */


### PR DESCRIPTION
## Summary
- Fixed syntax error in `constraint-helpers.js:230` where JSDoc comment was missing opening `/**`
- This error was causing `Uncaught SyntaxError: Unexpected token '*'` when loading the page

## Changes
- Added missing `/**` to properly open JSDoc comment block for `scoreMatchWithConstraints` function

## Notes
This same fix has already been applied to the dev branch via cherry-pick (commit b99aae1), so this PR primarily serves as documentation of the change.

🤖 Generated with [Claude Code](https://claude.ai/code)