### PR TITLE
Implement Two-Column Layout for Mapping Modal

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1339,7 +1339,9 @@ main {
 
 /* Wider modal for mapping */
 .modal.mapping-modal-wide {
-    max-width: 900px;
+    max-width: 900px !important;
+    width: unset !important;
+
 }
 
 .modal-header {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1411,6 +1411,7 @@ main {
     border-radius: 8px;
     background: #fafafa;
     overflow-y: auto;
+    max-height: 65vh;
 }
 
 .mapping-column.left-column {
@@ -1464,6 +1465,32 @@ main {
     background-color: var(--secondary-color);
     padding: 1rem;
     border-radius: 4px;
+    margin-bottom: 15px;
+}
+
+/* Two-column layout specific styles */
+.two-column-layout .property-search {
+    flex: 1;
+}
+
+.two-column-layout .property-search-input {
+    width: 100%;
+    margin-bottom: 10px;
+}
+
+.two-column-layout .property-suggestions {
+    max-height: 250px;
+    overflow-y: auto;
+}
+
+.two-column-layout .transformation-section {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.two-column-layout .transformation-section h4 {
+    color: var(--primary-color);
+    margin-bottom: 10px;
 }
 
 .key-info h4 {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1337,6 +1337,11 @@ main {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
+/* Wider modal for mapping */
+.modal.mapping-modal-wide {
+    max-width: 900px;
+}
+
 .modal-header {
     padding: 0.75rem;
     border-bottom: 1px solid var(--border-color);
@@ -1389,6 +1394,70 @@ main {
 .mapping-modal-content {
     display: flex;
     flex-direction: column;
+}
+
+/* Two-column layout for mapping modal */
+.mapping-modal-content.two-column-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    height: 100%;
+}
+
+.mapping-column {
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+    border-radius: 8px;
+    background: #fafafa;
+    overflow-y: auto;
+}
+
+.mapping-column.left-column {
+    border-right: 1px solid var(--border-color);
+    background: #f8f9fa;
+}
+
+.mapping-column.right-column {
+    background: #f9fafb;
+}
+
+.column-header {
+    font-size: 0.9em;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--border-color);
+}
+
+/* Modal header with mapping relationship */
+.mapping-relationship-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1.1em;
+    font-weight: 600;
+}
+
+.mapping-arrow {
+    color: #666;
+    font-size: 1.2em;
+}
+
+.mapping-source, .mapping-target {
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: #fff;
+    border: 1px solid var(--border-color);
+}
+
+.mapping-source.unmapped, .mapping-target.unmapped {
+    color: #999;
+    font-style: italic;
+    background: #f5f5f5;
 }
 
 .key-info {
@@ -1811,6 +1880,26 @@ pre.sample-value {
     
     .property-suggestions {
         max-height: 200px;
+    }
+    
+    /* Two-column layout responsive */
+    .modal.mapping-modal-wide {
+        max-width: 95%;
+    }
+    
+    .mapping-modal-content.two-column-layout {
+        grid-template-columns: 1fr;
+        gap: 15px;
+    }
+    
+    .mapping-column.left-column {
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
+    }
+    
+    .mapping-relationship-header {
+        flex-wrap: wrap;
+        font-size: 1em;
     }
 }
 

--- a/src/js/mapping/core/property-searcher.js
+++ b/src/js/mapping/core/property-searcher.js
@@ -9,6 +9,7 @@ import { eventSystem } from '../../events.js';
 import { showMessage, createElement, createListItem } from '../../ui/components.js';
 import { getCompletePropertyData } from '../../api/wikidata.js';
 import { refreshStage3TransformationUI as refreshStage3UI } from './transformation-engine.js';
+import { updateModalTitle, updateStage2Summary } from '../ui/modals/mapping-modal.js';
 
 // Additional imports needed for the functions
 // TODO: These helper functions will need to be extracted to mapping-helpers.js module:
@@ -542,26 +543,7 @@ export async function transitionToDataTypeConfiguration(property) {
     await displayDataTypeConfiguration(property);
 }
 
-/**
- * Update the modal title to show the mapping relationship
- */
-function updateModalTitle(property) {
-    const modalTitle = document.getElementById('modal-title');
-    if (modalTitle && window.currentMappingKeyData) {
-        const keyName = window.currentMappingKeyData.key || 'Key';
-        modalTitle.textContent = `${keyName} → ${property.label} (${property.id})`;
-    }
-}
-
-/**
- * Update Stage 2 summary to show detected data type
- */
-function updateStage2Summary(property) {
-    const stage2Summary = document.getElementById('stage-2-summary');
-    if (stage2Summary && property && property.datatypeLabel) {
-        stage2Summary.textContent = `Stage 2: Value type is ${property.datatypeLabel}`;
-    }
-}
+// updateModalTitle and updateStage2Summary are now imported from mapping-modal.js
 
 /**
  * Display data type configuration in Stage 2

--- a/src/js/mapping/ui/modals/mapping-modal.js
+++ b/src/js/mapping/ui/modals/mapping-modal.js
@@ -78,38 +78,49 @@ export function openMappingModal(keyData) {
             }
         ];
         
-        // Open modal
+        // Add class to modal for wider display
+        const modal = document.querySelector('.modal');
+        if (modal) {
+            modal.classList.add('mapping-modal-wide');
+        }
+        
+        // Open modal with mapping relationship header
+        const modalTitle = createMappingRelationshipTitle(keyData.key, null);
         modalUI.openModal(
-            `Map Key: ${keyData.key}`,
+            modalTitle,
             modalContent,
             buttons
         );
+        
+        // Remove the wide class when modal closes
+        const originalClose = modalUI.closeModal;
+        modalUI.closeModal = function() {
+            if (modal) {
+                modal.classList.remove('mapping-modal-wide');
+            }
+            return originalClose.apply(this, arguments);
+        };
     });
 }
 
 /**
- * Creates mapping modal content
+ * Creates mapping modal content with two-column layout
  */
 export function createMappingModalContent(keyData) {
     const container = createElement('div', {
-        className: 'mapping-modal-content'
+        className: 'mapping-modal-content two-column-layout'
     });
     
-    // Stage 1: Key Information and Property Selection (Collapsible)
-    const stage1Section = createElement('details', {
-        className: 'mapping-stage',
-        id: 'stage-1-property-selection',
-        open: true // Open by default
+    // LEFT COLUMN - Omeka S Data
+    const leftColumn = createElement('div', {
+        className: 'mapping-column left-column'
     });
     
-    const stage1Summary = createElement('summary', {
-        className: 'stage-summary'
-    }, 'Stage 1: Property Selection');
-    stage1Section.appendChild(stage1Summary);
-    
-    const stage1Content = createElement('div', {
-        className: 'stage-content'
-    });
+    // Column header
+    const leftHeader = createElement('div', {
+        className: 'column-header'
+    }, 'Omeka S Data');
+    leftColumn.appendChild(leftHeader);
     
     // Key information section
     const keyInfo = createElement('div', {
@@ -128,14 +139,40 @@ export function createMappingModalContent(keyData) {
         <p><strong>Frequency:</strong> ${keyData.frequency || 1} out of ${keyData.totalItems || 1} items</p>
         <div><strong>Sample Value:</strong> ${sampleValueHtml}</div>
     `;
-    stage1Content.appendChild(keyInfo);
+    leftColumn.appendChild(keyInfo);
+    
+    // Value transformation section (Stage 3)
+    const transformationSection = createElement('div', {
+        className: 'transformation-section',
+        style: 'margin-top: 20px;'
+    });
+    
+    const transformationHeader = createElement('h4', {}, 'Value Transformation');
+    transformationSection.appendChild(transformationHeader);
+    
+    const valueTransformationContainer = renderValueTransformationUI(keyData, window.mappingStepState);
+    transformationSection.appendChild(valueTransformationContainer);
+    leftColumn.appendChild(transformationSection);
+    
+    container.appendChild(leftColumn);
+    
+    // RIGHT COLUMN - Wikidata Property
+    const rightColumn = createElement('div', {
+        className: 'mapping-column right-column'
+    });
+    
+    // Column header
+    const rightHeader = createElement('div', {
+        className: 'column-header'
+    }, 'Wikidata Property');
+    rightColumn.appendChild(rightHeader);
     
     // Property search section
     const searchSection = createElement('div', {
         className: 'property-search'
     });
     searchSection.innerHTML = `
-        <h4>Search Wikidata Properties</h4>
+        <h4>Search Properties</h4>
         <input type="text" id="property-search-input" placeholder="Type to search for Wikidata properties..." class="property-search-input">
         <div id="property-suggestions" class="property-suggestions"></div>
         <div id="selected-property" class="selected-property" style="display: none;">
@@ -150,66 +187,25 @@ export function createMappingModalContent(keyData) {
             </div>
         </div>
     `;
-    stage1Content.appendChild(searchSection);
-    stage1Section.appendChild(stage1Content);
-    container.appendChild(stage1Section);
+    rightColumn.appendChild(searchSection);
     
-    // Stage 2: Value Type Detection (Initially hidden)
-    const stage2Section = createElement('details', {
-        className: 'mapping-stage',
-        id: 'stage-2-value-type-detection'
-    });
-    
-    const stage2Summary = createElement('summary', {
-        className: 'stage-summary',
-        id: 'stage-2-summary'
-    }, 'Stage 2: Value Type Detection');
-    stage2Section.appendChild(stage2Summary);
-    
-    const stage2Content = createElement('div', {
-        className: 'stage-content'
-    });
-    
-    // Data type information section
+    // Data type information section (Stage 2 content)
     const dataTypeInfo = createElement('div', {
         className: 'datatype-info',
-        id: 'datatype-info-section'
+        id: 'datatype-info-section',
+        style: 'margin-top: 20px; display: none;'
     });
     dataTypeInfo.innerHTML = `
         <div class="datatype-display">
-            <h4>Detected Data Type</h4>
+            <h4>Expected Value Type</h4>
             <div id="detected-datatype" class="detected-datatype">
-                <div class="datatype-loading">Select a property to detect data type...</div>
+                <div class="datatype-loading">Select a property to see expected type...</div>
             </div>
         </div>
-        <div class="datatype-description" id="datatype-description" style="display: none;">
-            <p>Additional configuration options will be available here in future versions.</p>
-        </div>
     `;
-    stage2Content.appendChild(dataTypeInfo);
-    stage2Section.appendChild(stage2Content);
-    container.appendChild(stage2Section);
+    rightColumn.appendChild(dataTypeInfo);
     
-    // Stage 3: Value Transformation (Initially hidden)
-    const stage3Section = createElement('details', {
-        className: 'mapping-stage',
-        id: 'stage-3-value-transformation'
-    });
-    
-    const stage3Summary = createElement('summary', {
-        className: 'stage-summary'
-    }, 'Stage 3: Value Transformation');
-    stage3Section.appendChild(stage3Summary);
-    
-    const stage3Content = createElement('div', {
-        className: 'stage-content'
-    });
-    
-    // Value transformation section
-    const valueTransformationContainer = renderValueTransformationUI(keyData, window.mappingStepState);
-    stage3Content.appendChild(valueTransformationContainer);
-    stage3Section.appendChild(stage3Content);
-    container.appendChild(stage3Section);
+    container.appendChild(rightColumn);
     
     // Setup search functionality and pre-populate if mapped
     setTimeout(() => setupPropertySearch(keyData, window.mappingStepState), 100);
@@ -225,13 +221,27 @@ export function getSelectedPropertyFromModal() {
 }
 
 /**
+ * Create mapping relationship title with arrow
+ */
+function createMappingRelationshipTitle(keyName, property) {
+    const sourceSpan = `<span class="mapping-source">${keyName}</span>`;
+    const arrow = `<span class="mapping-arrow">→</span>`;
+    const targetSpan = property 
+        ? `<span class="mapping-target">${property.label} (${property.id})</span>`
+        : `<span class="mapping-target unmapped">unmapped</span>`;
+    
+    return `<div class="mapping-relationship-header">${sourceSpan} ${arrow} ${targetSpan}</div>`;
+}
+
+/**
  * Update the modal title to show the mapping relationship
  */
 export function updateModalTitle(property) {
     const modalTitle = document.getElementById('modal-title');
     if (modalTitle && window.currentMappingKeyData) {
         const keyName = window.currentMappingKeyData.key || 'Key';
-        modalTitle.textContent = `${keyName} → ${property.label} (${property.id})`;
+        const titleHtml = createMappingRelationshipTitle(keyName, property);
+        modalTitle.innerHTML = titleHtml;
     }
 }
 
@@ -239,8 +249,16 @@ export function updateModalTitle(property) {
  * Update Stage 2 summary to show detected data type
  */
 export function updateStage2Summary(property) {
-    const stage2Summary = document.getElementById('stage-2-summary');
-    if (stage2Summary && property && property.datatypeLabel) {
-        stage2Summary.textContent = `Stage 2: Value type is ${property.datatypeLabel}`;
+    // In two-column layout, update the datatype section visibility and content
+    const datatypeSection = document.getElementById('datatype-info-section');
+    const datatypeDisplay = document.getElementById('detected-datatype');
+    
+    if (datatypeSection && datatypeDisplay && property && property.datatypeLabel) {
+        datatypeSection.style.display = 'block';
+        datatypeDisplay.innerHTML = `
+            <div class="datatype-item">
+                <strong>Type:</strong> ${property.datatypeLabel}
+            </div>
+        `;
     }
 }

--- a/src/js/mapping/ui/modals/mapping-modal.js
+++ b/src/js/mapping/ui/modals/mapping-modal.js
@@ -78,28 +78,28 @@ export function openMappingModal(keyData) {
             }
         ];
         
-        // Add class to modal for wider display
-        const modal = document.querySelector('.modal');
-        if (modal) {
-            modal.classList.add('mapping-modal-wide');
-        }
-        
         // Open modal with mapping relationship header
         const modalTitle = createMappingRelationshipTitle(keyData.key, null);
         modalUI.openModal(
             modalTitle,
             modalContent,
-            buttons
+            buttons,
+            () => {
+                // Remove the wide class when modal closes
+                const modal = document.querySelector('.modal');
+                if (modal) {
+                    modal.classList.remove('mapping-modal-wide');
+                }
+            }
         );
         
-        // Remove the wide class when modal closes
-        const originalClose = modalUI.closeModal;
-        modalUI.closeModal = function() {
+        // Add class to modal for wider display after opening
+        setTimeout(() => {
+            const modal = document.querySelector('.modal');
             if (modal) {
-                modal.classList.remove('mapping-modal-wide');
+                modal.classList.add('mapping-modal-wide');
             }
-            return originalClose.apply(this, arguments);
-        };
+        }, 0);
     });
 }
 

--- a/src/js/ui/modal-ui.js
+++ b/src/js/ui/modal-ui.js
@@ -53,7 +53,12 @@ export function setupModalUI() {
     function openModal(title, content, buttons = [], onClose = null) {
         // Set title
         if (modalTitle) {
-            modalTitle.textContent = title;
+            // Check if title contains HTML tags
+            if (typeof title === 'string' && title.includes('<')) {
+                modalTitle.innerHTML = title;
+            } else {
+                modalTitle.textContent = title;
+            }
         }
         
         // Set content


### PR DESCRIPTION
## Summary

This PR redesigns the mapping modal with a logical two-column layout that separates source data (Omeka S) from target mapping (Wikidata properties):

- **Left Column**: Omeka S data including key information, sample values, and value transformation controls
- **Right Column**: Wikidata property search, selection, and expected value type information
- **Enhanced Header**: Shows mapping relationship as `Key Name → Property Label` with styled elements
- **Wider Modal**: Increased from 600px to 900px for better space utilization

## Key Improvements

- **Better Workflow**: All sections visible simultaneously - no more collapsible stages
- **Clear Visual Separation**: Distinct columns make the mapping relationship intuitive
- **Improved Space Usage**: Two-column layout accommodates more content without scrolling
- **Enhanced UX**: Mapping relationship clearly shown in header with proper styling
- **Responsive Design**: Columns stack vertically on mobile screens

## Technical Changes

### UI Structure
- Replaced three-stage collapsible accordion with two-column grid layout
- Removed `<details>` elements in favor of always-visible sections
- Added `.two-column-layout` CSS class with responsive grid

### Modal Enhancements
- Updated modal width to 900px with `.mapping-modal-wide` class
- Fixed HTML rendering in modal titles (was showing raw HTML tags)
- Improved modal lifecycle management with proper cleanup

### Left Column Content
- Key information display (name, frequency, sample value)
- Value transformation controls (Stage 3 functionality)
- Field selector for complex JSON objects

### Right Column Content  
- Property search input and suggestions
- Selected property details and constraints
- Expected value type information (Stage 2 functionality)

## Files Modified
- `src/css/style.css` - Two-column layout styles and responsive design
- `src/js/mapping/ui/modals/mapping-modal.js` - Modal structure and header logic
- `src/js/ui/modal-ui.js` - HTML title rendering support
- `src/js/mapping/core/property-searcher.js` - Import updates for title functions

## Test Plan
- [x] Modal opens with proper two-column layout
- [x] Header shows "Key Name → unmapped" initially
- [x] Property search works in right column  
- [x] Property selection updates header to show "Key Name → Property Label (ID)"
- [x] Value transformation controls work in left column
- [x] Modal displays at correct 900px width
- [x] Responsive design works on smaller screens
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)