### PR TITLE
Fix unnecessary property loading console logs in mapping modal

### DIFF
--- a/src/js/api/wikidata.js
+++ b/src/js/api/wikidata.js
@@ -434,7 +434,7 @@ function humanizeRegexDescription(regex, fallbackDescription) {
  * @param {string} type - Cache type ('info' or 'constraints')
  * @returns {Object|null} Cached data or null if not found/expired
  */
-function getCachedProperty(propertyId, type) {
+export function getCachedProperty(propertyId, type) {
     const cacheKey = `${propertyId}-${type}`;
     const cached = propertyCache.get(cacheKey);
     


### PR DESCRIPTION
## Summary
- Fixed misleading console logs that appeared every time the mapping modal opened
- Added intelligent cache checking to only show loading messages when API calls are actually made
- Improved debugging experience with accurate cache hit/miss reporting

## Changes Made
- **Modified `setupEntitySchemaPropertySelection()`** in `property-searcher.js` to check cache status before logging
- **Exported `getCachedProperty()`** from `wikidata.js` module for cache checking
- **Updated console logging** to show different messages for cached vs uncached data
- **Added completion messages** that reflect actual work done vs cache hits

## Test Plan
- [x] Load application and select an entity schema
- [x] Open mapping modal for the first time → shows "🚀 Batch loading X properties"
- [x] Close and reopen modal → shows "✨ Using cached data for X properties" 
- [x] Verify no misleading loading messages when data is already cached
- [x] Test mixed scenarios with some cached and some uncached properties

## Console Output Examples

**First time (uncached properties):**
```
🚀 Batch loading 5 entity schema properties: P1476, P577, P31, P159, P17
✅ Batch loading complete for 5 properties.
```

**Subsequent opens (cached properties):**
```
✨ Using cached data for 5 entity schema properties
```

**Mixed scenarios:**
```
🚀 Batch loading 2 entity schema properties: P123, P456
✨ Using cached data for 3 entity schema properties
✅ Batch loading complete for 2 properties. 3 loaded from cache.
```

🤖 Generated with [Claude Code](https://claude.ai/code)