### PR TITLE
Apply transformations to values in reconciliation step

### DIFF
--- a/src/js/reconciliation/core/batch-processor.js
+++ b/src/js/reconciliation/core/batch-processor.js
@@ -33,8 +33,8 @@ export function createBatchAutoAcceptanceProcessor(dependencies) {
             const itemId = `item-${index}`;
             mappedKeys.forEach(keyObj => {
                 const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
-                // Pass the full keyObj to extractPropertyValues to handle @ field selection
-                const values = extractPropertyValues(item, keyObj);
+                // Pass the full keyObj and state to extractPropertyValues to apply transformations and handle @ field selection
+                const values = extractPropertyValues(item, keyObj, state);
                 
                 values.forEach((value, valueIndex) => {
                     batchJobs.push({

--- a/src/js/reconciliation/ui/reconciliation-table.js
+++ b/src/js/reconciliation/ui/reconciliation-table.js
@@ -293,7 +293,8 @@ export function createReconciliationTableFactory(dependencies) {
         getWikidataUrlForProperty,
         performBatchAutoAcceptance,
         restoreReconciliationDisplay,
-        openReconciliationModal
+        openReconciliationModal,
+        state
     } = dependencies;
 
     const createPropertyCell = createPropertyCellFactory(openReconciliationModal);
@@ -471,8 +472,8 @@ export function createReconciliationTableFactory(dependencies) {
                         // Handle mapped property cell
                         const keyObj = propItem.data;
                         const keyName = typeof keyObj === 'string' ? keyObj : keyObj.key;
-                        // Pass the full keyObj to preserve @ field information for duplicate mappings
-                        const values = extractPropertyValues(item, keyObj);
+                        // Pass the full keyObj and state to apply transformations and preserve @ field information
+                        const values = extractPropertyValues(item, keyObj, state);
                         
                         if (values.length === 0) {
                             // Empty cell

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -240,7 +240,8 @@ export function setupReconciliationStep(state) {
             getWikidataUrlForProperty,
             performBatchAutoAcceptance,
             restoreReconciliationDisplay,
-            openReconciliationModal
+            openReconciliationModal,
+            state
         });
         
         const createPropertyCell = createPropertyCellFactory(openReconciliationModal);
@@ -412,7 +413,7 @@ export function setupReconciliationStep(state) {
             state.setReconciliationProgress(0, totalCells);
             
             // Initialize reconciliation data structure using extracted function
-            const newData = modules.initializeReconciliationDataStructure(data, mappedKeys, manualProperties);
+            const newData = modules.initializeReconciliationDataStructure(data, mappedKeys, manualProperties, state);
             // Clear existing data and copy new data (mutate, don't reassign)
             Object.keys(reconciliationData).forEach(key => delete reconciliationData[key]);
             Object.assign(reconciliationData, newData);


### PR DESCRIPTION
## Summary
- Fixed issue where reconciliation table showed original values instead of transformed values
- Reconciliation step now properly applies transformations configured during mapping
- URL transformations (e.g., simplifying URLs to identifiers) are now applied throughout reconciliation

## Changes Made
### Core Integration
- **Modified `extractPropertyValues()`** to apply transformations when state object is provided
- **Updated reconciliation data initialization** to pass state for transformation application  
- **Updated reconciliation table factory** to use transformed values in display
- **Updated batch processor** to apply transformations during auto-acceptance

### Files Changed
- `src/js/reconciliation/core/reconciliation-data.js` - Core transformation integration
- `src/js/reconciliation/ui/reconciliation-table.js` - Table display using transformed values
- `src/js/reconciliation/core/batch-processor.js` - Batch processing with transformations
- `src/js/steps/reconciliation.js` - State passing for transformation application

## Test Results
✅ **Transformation Integration Test**
- Without transformations: `['https://www.example.org/items/12345']`
- With transformations: `['12345']` (URL simplified correctly)

✅ **Reconciliation Data Structure Test**  
- Verified reconciliation data initialization uses transformed values
- Confirmed backward compatibility maintained

## Impact
- **Reconciliation table cells** now display simplified transformed values
- **Reconciliation modal** works with transformed values for entity matching
- **Final export** uses properly transformed data
- **Backward compatibility** maintained - no breaking changes

## Before/After
**Before**: Reconciliation table showed full URLs like `https://www.example.org/items/12345`
**After**: Reconciliation table shows simplified identifiers like `12345` (based on configured transformations)

🤖 Generated with [Claude Code](https://claude.ai/code)