### PR TITLE
Fix OCLC identifier [object Object] display issue

### DIFF
--- a/src/js/reconciliation/core/reconciliation-data.js
+++ b/src/js/reconciliation/core/reconciliation-data.js
@@ -82,50 +82,28 @@ export function extractPropertyValues(item, keyOrKeyObj) {
     
     // Helper function to extract value from a single object
     const extractFromObject = (v) => {
-        // Debug logging for OCLC identifiers
-        if (typeof v === 'object' && v['@id'] && v['@id'].includes('oclc')) {
-            console.log('🔍 OCLC identifier found:', v, 'selectedAtField:', selectedAtField);
-        }
-        
         // If a specific @ field is selected, ONLY return that field's value
         if (selectedAtField) {
             if (typeof v === 'object' && v[selectedAtField] !== undefined) {
-                const result = String(v[selectedAtField]);
-                if (v['@id'] && v['@id'].includes('oclc')) {
-                    console.log('🔍 OCLC extracted (selectedAtField):', result);
-                }
-                return result;
+                return String(v[selectedAtField]);
             } else {
                 // Don't fall back to default extraction when a specific @ field is requested
                 // Return null to indicate this object doesn't have the requested field
-                if (v['@id'] && v['@id'].includes('oclc')) {
-                    console.log('🔍 OCLC selectedAtField not found, returning null');
-                }
                 return null;
             }
         }
         
         // Default extraction logic (only when no specific @ field is selected)
         if (typeof v === 'object' && v['o:label']) {
-            const result = v['o:label'];
-            if (v['@id'] && v['@id'].includes('oclc')) {
-                console.log('🔍 OCLC extracted (o:label):', result);
-            }
-            return result;
+            return v['o:label'];
         } else if (typeof v === 'object' && v['@value']) {
-            const result = v['@value'];
-            if (v['@id'] && v['@id'].includes('oclc')) {
-                console.log('🔍 OCLC extracted (@value):', result);
-            }
-            return result;
+            return v['@value'];
+        } else if (typeof v === 'object' && v['@id']) {
+            return v['@id'];
         } else if (typeof v === 'string') {
             return v;
         } else {
-            const result = String(v);
-            if (typeof v === 'object' && v['@id'] && v['@id'].includes('oclc')) {
-                console.log('🔍 OCLC extracted (String fallback):', result);
-            }
-            return result;
+            return String(v);
         }
     };
     

--- a/src/js/reconciliation/ui/reconciliation-table.js
+++ b/src/js/reconciliation/ui/reconciliation-table.js
@@ -213,11 +213,6 @@ export function createPropertyCellFactory(openReconciliationModal) {
  * Create a value element within a property cell
  */
 function createValueElement(itemId, property, valueIndex, value, openReconciliationModal) {
-    // Debug logging for [object Object] issue
-    if (typeof value === 'object') {
-        console.error('🚨 createValueElement received object value:', value, 'for property:', property);
-    }
-    
     const valueDiv = createElement('div', {
         className: 'property-value',
         dataset: { status: 'pending' }


### PR DESCRIPTION
## Summary
- Fixed OCLC identifiers displaying as "[object Object]" in reconciliation table
- Root cause: Missing `@id` extraction in `extractFromObject` function
- OCLC identifier objects have WorldCat URLs in `@id` field but extraction logic only checked `o:label` and `@value`

## Root Cause Analysis
OCLC identifiers are stored as objects:
```json
{
  "@id": "https://maastrichtuniversity.on.worldcat.org/oclc/65042490",
  "type": "uri", 
  "property_label": "sameAs"
}
```

The `extractFromObject` function in `reconciliation-data.js` was missing the `@id` case in default extraction logic, causing objects to fall through to `String(v)` = "[object Object]".

## Changes Made
- **Added `@id` extraction** to `extractFromObject` function in `reconciliation-data.js`
- **Fixed value extraction order**: `o:label` → `@value` → `@id` → string fallback
- **Removed debug logging** added during investigation

## Test Plan
- [x] Load data with OCLC identifiers (schema:sameAs fields)
- [x] Verify auto-mapping to OCLC control number (P243) works
- [x] Navigate to reconciliation step  
- [x] Confirm OCLC identifiers display WorldCat URLs instead of "[object Object]"
- [x] Verify reconciliation modal opens correctly with proper values

## Impact
- OCLC identifiers now display correctly: `https://maastrichtuniversity.on.worldcat.org/oclc/65042490`
- Fixes auto-mapped identifier fields in reconciliation workflow
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)