### PR TITLE
Fix reconciliation table update when mapping changes

### DIFF
--- a/src/js/mapping/ui/mapping-lists.js
+++ b/src/js/mapping/ui/mapping-lists.js
@@ -580,6 +580,15 @@ export function mapKeyToProperty(keyData, property, state) {
     
     // Use moveKeyToCategory to handle the movement properly
     moveKeyToCategory(mappedKey, 'mapped', state);
+    
+    // Publish mapping updated event for reconciliation table updates
+    eventSystem.publish(eventSystem.Events.MAPPING_UPDATED, {
+        type: 'mapped',
+        keyData: mappedKey,
+        previousKeyData: keyData,
+        property: property,
+        mappingId: mappingId
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed the issue where the reconciliation table doesn't update when column header mappings are changed
- Implemented real-time table updates that only refresh the affected column for better performance
- Preserved existing reconciliation progress while ensuring data consistency

## Changes Made
- **Event System**: Added `MAPPING_UPDATED` event publishing when mappings change in `mapKeyToProperty()`
- **Event Subscription**: Added listener in reconciliation step to detect mapping changes
- **Partial Table Update**: Created `updateTableForMappingChange()` function that updates only the affected column
- **Data Consistency**: Re-extracts property values with updated @ field selections and transformations
- **State Preservation**: Maintains existing reconciliation progress for unaffected properties

## Technical Details
- **Performance**: Only updates affected column instead of regenerating entire table
- **Real-time**: Changes in mapping modal are immediately reflected in reconciliation table  
- **Smart Updates**: Handles property label changes, @ field updates, and transformation modifications
- **State Management**: Resets reconciliation status for changed properties while preserving others

## Test Plan
- [x] Click column header in reconciliation step → opens mapping modal
- [x] Change property mapping → table updates with new property info
- [x] Change @ field selection → table shows updated data values
- [x] Existing reconciliation progress preserved for other columns
- [x] Click handlers work correctly on updated cells

🤖 Generated with [Claude Code](https://claude.ai/code)