### PR TITLE
Fix reconciliation modal click issues - comprehensive solution

### DIFF
--- a/src/js/reconciliation/ui/modals/modal-factory.js
+++ b/src/js/reconciliation/ui/modals/modal-factory.js
@@ -1,0 +1,235 @@
+/**
+ * Modal Factory for Reconciliation Data Types
+ * @module reconciliation/ui/modals/modal-factory
+ * 
+ * Central factory for creating and managing reconciliation modals based on data type.
+ * Provides consistent interface for all modal types and handles routing to appropriate
+ * specialized modal implementations.
+ * 
+ * Supported modal types:
+ * - wikibase-item: Wikidata entity reconciliation
+ * - string: Text string validation and editing (future)
+ * - time: Date/time reconciliation (future)
+ * - quantity: Number/quantity reconciliation (future)
+ * - url: URL validation (future)
+ * - monolingualtext: Text with language specification (future)
+ */
+
+import { 
+    createWikidataItemModal, 
+    initializeWikidataItemModal 
+} from './wikidata-item-modal.js';
+import { 
+    createStringModal, 
+    initializeStringModal 
+} from './string-modal.js';
+
+/**
+ * Registry of modal handlers by data type
+ */
+const modalRegistry = {
+    'wikibase-item': {
+        create: createWikidataItemModal,
+        initialize: initializeWikidataItemModal,
+        name: 'Wikidata Item Reconciliation'
+    },
+    'string': {
+        create: createStringModal,
+        initialize: initializeStringModal,
+        name: 'String Validation'
+    }
+    // Future modal types will be registered here:
+    // 'time': { create: createTimeModal, initialize: initializeTimeModal, name: 'Date/Time Selection' },
+    // 'quantity': { create: createQuantityModal, initialize: initializeQuantityModal, name: 'Number/Quantity Input' },
+    // 'url': { create: createUrlModal, initialize: initializeUrlModal, name: 'URL Validation' },
+    // 'monolingualtext': { create: createMonolingualModal, initialize: initializeMonolingualModal, name: 'Text with Language' }
+};
+
+/**
+ * Create reconciliation modal based on data type
+ * @param {string} dataType - The data type (wikibase-item, string, time, etc.)
+ * @param {string} itemId - Item ID being reconciled
+ * @param {string} property - Property name being reconciled
+ * @param {number} valueIndex - Index of value within property
+ * @param {string} value - The value to reconcile
+ * @param {Object} propertyData - Property metadata and constraints
+ * @param {Array} existingMatches - Pre-existing matches if available
+ * @returns {HTMLElement} Modal content element
+ * @throws {Error} If data type is not supported
+ */
+export function createReconciliationModalByType(dataType, itemId, property, valueIndex, value, propertyData = null, existingMatches = null) {
+    const modalHandler = modalRegistry[dataType];
+    
+    if (!modalHandler) {
+        throw new Error(`Unsupported reconciliation modal type: ${dataType}. Supported types: ${Object.keys(modalRegistry).join(', ')}`);
+    }
+    
+    console.log(`Creating ${modalHandler.name} for ${dataType} value:`, value);
+    
+    try {
+        const modalElement = modalHandler.create(itemId, property, valueIndex, value, propertyData, existingMatches);
+        
+        // Add common modal metadata
+        modalElement.dataset.modalFactory = 'reconciliation';
+        modalElement.dataset.dataType = dataType;
+        modalElement.dataset.modalName = modalHandler.name;
+        
+        return modalElement;
+    } catch (error) {
+        console.error(`Error creating ${modalHandler.name}:`, error);
+        throw new Error(`Failed to create reconciliation modal for type ${dataType}: ${error.message}`);
+    }
+}
+
+/**
+ * Initialize reconciliation modal after DOM insertion
+ * @param {HTMLElement} modalElement - The modal element to initialize
+ * @throws {Error} If modal type cannot be determined or is not supported
+ */
+export function initializeReconciliationModal(modalElement) {
+    if (!modalElement) {
+        throw new Error('Modal element is required for initialization');
+    }
+    
+    const dataType = modalElement.dataset.dataType;
+    if (!dataType) {
+        throw new Error('Modal element missing data-type attribute');
+    }
+    
+    const modalHandler = modalRegistry[dataType];
+    if (!modalHandler) {
+        throw new Error(`No modal handler found for data type: ${dataType}`);
+    }
+    
+    console.log(`Initializing ${modalHandler.name} for ${dataType}`);
+    
+    try {
+        modalHandler.initialize(modalElement);
+    } catch (error) {
+        console.error(`Error initializing ${modalHandler.name}:`, error);
+        throw new Error(`Failed to initialize reconciliation modal for type ${dataType}: ${error.message}`);
+    }
+}
+
+/**
+ * Get list of supported modal types
+ * @returns {Array<string>} Array of supported data type strings
+ */
+export function getSupportedModalTypes() {
+    return Object.keys(modalRegistry);
+}
+
+/**
+ * Check if a data type is supported
+ * @param {string} dataType - Data type to check
+ * @returns {boolean} True if supported, false otherwise
+ */
+export function isModalTypeSupported(dataType) {
+    return modalRegistry.hasOwnProperty(dataType);
+}
+
+/**
+ * Get modal information for a data type
+ * @param {string} dataType - Data type to get info for
+ * @returns {Object|null} Modal info object or null if not supported
+ */
+export function getModalTypeInfo(dataType) {
+    const modalHandler = modalRegistry[dataType];
+    if (!modalHandler) {
+        return null;
+    }
+    
+    return {
+        dataType: dataType,
+        name: modalHandler.name,
+        supported: true
+    };
+}
+
+/**
+ * Register a new modal type (for future extensibility)
+ * @param {string} dataType - Data type identifier
+ * @param {Function} createFunction - Function to create modal
+ * @param {Function} initializeFunction - Function to initialize modal
+ * @param {string} name - Human-readable name for the modal type
+ */
+export function registerModalType(dataType, createFunction, initializeFunction, name) {
+    if (modalRegistry[dataType]) {
+        console.warn(`Modal type ${dataType} is already registered. Overwriting.`);
+    }
+    
+    modalRegistry[dataType] = {
+        create: createFunction,
+        initialize: initializeFunction,
+        name: name
+    };
+    
+    console.log(`Registered modal type: ${dataType} (${name})`);
+}
+
+/**
+ * Create fallback modal for unsupported types
+ * This will be used until specific modal types are implemented
+ * @param {string} dataType - The unsupported data type
+ * @param {string} value - The value to display
+ * @returns {HTMLElement} Fallback modal element
+ */
+export function createFallbackModal(dataType, value) {
+    const modalContent = document.createElement('div');
+    modalContent.className = 'fallback-modal';
+    modalContent.dataset.modalType = 'fallback';
+    modalContent.dataset.dataType = dataType;
+    
+    modalContent.innerHTML = `
+        <div class="modal-header">
+            <div class="data-type-indicator">
+                <span class="data-type-label">Type:</span>
+                <span class="data-type-value">${escapeHtml(dataType)}</span>
+            </div>
+        </div>
+
+        <div class="value-display">
+            <div class="section-title">Value</div>
+            <div class="current-value">${escapeHtml(value)}</div>
+        </div>
+
+        <div class="fallback-section">
+            <div class="fallback-message">
+                <h3>Modal Not Yet Implemented</h3>
+                <p>A specialized reconciliation interface for <strong>${escapeHtml(dataType)}</strong> values is not yet available.</p>
+                <p>For now, you can:</p>
+                <ul>
+                    <li>Use the current value as-is</li>
+                    <li>Skip this reconciliation</li>
+                    <li>Manually edit the value</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="modal-actions">
+            <button class="btn btn-secondary" onclick="closeReconciliationModal()">Cancel</button>
+            <button class="btn btn-primary" onclick="confirmFallbackValue()">Use Current Value</button>
+        </div>
+    `;
+    
+    return modalContent;
+}
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// Global fallback handler
+window.confirmFallbackValue = function() {
+    console.log('Using fallback value confirmation');
+    if (typeof window.closeReconciliationModal === 'function') {
+        window.closeReconciliationModal();
+    }
+};

--- a/src/js/reconciliation/ui/modals/string-modal.js
+++ b/src/js/reconciliation/ui/modals/string-modal.js
@@ -1,0 +1,242 @@
+/**
+ * String Reconciliation Modal
+ * @module reconciliation/ui/modals/string-modal
+ * 
+ * Specialized modal interface for string value validation and editing.
+ * Handles constraint validation, real-time feedback, and suggested corrections.
+ * 
+ * Features:
+ * - Constraint-based validation using Wikidata property patterns
+ * - Real-time validation feedback as user types
+ * - Suggested fixes for common format issues
+ * - Interactive editing with constraint examples
+ * - Format pattern display and explanation
+ */
+
+import { 
+    extractRegexConstraints, 
+    validateStringValue, 
+    validateRealTime, 
+    getSuggestedFixes,
+    createValidationUI,
+    setupLiveValidation
+} from '../validation-engine.js';
+
+/**
+ * Create String reconciliation modal content
+ * @param {string} itemId - Item ID being reconciled
+ * @param {string} property - Property name being reconciled
+ * @param {number} valueIndex - Index of value within property
+ * @param {string} value - The value to reconcile
+ * @param {Object} propertyData - Property metadata and constraints
+ * @param {Array} existingMatches - Not used for string values
+ * @returns {HTMLElement} Modal content element
+ */
+export function createStringModal(itemId, property, valueIndex, value, propertyData = null, existingMatches = null) {
+    const regexConstraints = extractRegexConstraints(property, propertyData);
+    const validationResult = validateStringValue(value, regexConstraints);
+    
+    const modalContent = document.createElement('div');
+    modalContent.className = 'string-modal';
+    
+    // Store context for modal interactions
+    modalContent.dataset.modalType = 'string';
+    modalContent.dataset.itemId = itemId;
+    modalContent.dataset.property = property;
+    modalContent.dataset.valueIndex = valueIndex;
+    modalContent.dataset.value = value;
+    if (propertyData) {
+        modalContent.dataset.propertyData = JSON.stringify(propertyData);
+    }
+    
+    modalContent.innerHTML = `
+        <div class="modal-header">
+            <div class="data-type-indicator">
+                <span class="data-type-label">Expected:</span>
+                <span class="data-type-value">Text String</span>
+            </div>
+        </div>
+
+        <div class="value-display">
+            <div class="section-title">Omeka S Value</div>
+            <div class="original-value">${escapeHtml(value)}</div>
+        </div>
+
+        <div class="string-section">
+            <!-- String Value Display -->
+            <div class="string-value-display">
+                <div class="section-title">String Value</div>
+                <div class="current-value" id="current-value">${escapeHtml(value)}</div>
+                ${validationResult ? `
+                    <div class="validation-status ${validationResult.isValid ? 'valid' : 'invalid'}">
+                        <span class="status-icon">${validationResult.isValid ? '✓' : '✗'}</span>
+                        <span class="status-text">${validationResult.message}</span>
+                    </div>
+                ` : ''}
+            </div>
+
+            <!-- String Editor (always available) -->
+            <div class="string-editor">
+                <div class="section-title">Edit Value</div>
+                <textarea id="string-editor" class="string-input" placeholder="Edit the string value...">${escapeHtml(value)}</textarea>
+                <div class="editor-validation" id="editor-validation"></div>
+                <button class="btn btn-primary" onclick="updateStringValue()">Update Value</button>
+            </div>
+
+            <!-- Constraint Information -->
+            ${regexConstraints ? `
+                <div class="constraint-info">
+                    <div class="section-title">Validation Rules</div>
+                    <div class="constraint-details">
+                        <div class="constraint-pattern">
+                            <span class="constraint-label">Pattern:</span>
+                            <code class="constraint-regex">${escapeHtml(regexConstraints.pattern)}</code>
+                        </div>
+                        ${regexConstraints.description ? `
+                            <div class="constraint-description">${escapeHtml(regexConstraints.description)}</div>
+                        ` : ''}
+                    </div>
+                </div>
+            ` : ''}
+        </div>
+
+        <div class="modal-actions">
+            <button class="btn btn-secondary" onclick="closeReconciliationModal()">Cancel</button>
+            <button class="btn btn-primary" id="confirm-btn" onclick="confirmStringValue()" ${validationResult && !validationResult.isValid ? 'disabled' : ''}>Confirm</button>
+        </div>
+    `;
+
+    return modalContent;
+}
+
+/**
+ * Initialize String modal after DOM insertion
+ * @param {HTMLElement} modalElement - The modal element
+ */
+export function initializeStringModal(modalElement) {
+    const value = modalElement.dataset.value;
+    const property = modalElement.dataset.property;
+    const propertyData = modalElement.dataset.propertyData ? 
+        JSON.parse(modalElement.dataset.propertyData) : null;
+    
+    // Store modal context globally for interaction handlers
+    window.currentModalContext = {
+        itemId: modalElement.dataset.itemId,
+        property: property,
+        valueIndex: parseInt(modalElement.dataset.valueIndex),
+        originalValue: value,
+        currentValue: value,
+        propertyData: propertyData,
+        dataType: 'string',
+        modalType: 'string'
+    };
+    
+    // Set up live validation for string inputs
+    const stringEditor = document.getElementById('string-editor');
+    const validationContainer = document.getElementById('editor-validation');
+    
+    if (stringEditor && validationContainer) {
+        const constraints = extractRegexConstraints(property, propertyData);
+        if (constraints) {
+            setupLiveValidation(stringEditor, constraints, validationContainer);
+        }
+    }
+    
+    // Initial validation state check
+    const constraints = extractRegexConstraints(property, propertyData);
+    const validation = validateStringValue(value, constraints);
+    const confirmBtn = document.getElementById('confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = !validation.isValid;
+    }
+}
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// Global interaction handlers for String modal
+window.updateStringValue = function() {
+    const editor = document.getElementById('string-editor');
+    const currentValueDisplay = document.getElementById('current-value');
+    const validationContainer = document.getElementById('editor-validation');
+    
+    if (!editor || !currentValueDisplay) return;
+    
+    const newValue = editor.value.trim();
+    if (!newValue) return;
+    
+    // Update display
+    currentValueDisplay.textContent = newValue;
+    
+    // Get constraints from current modal context
+    const property = window.currentModalContext?.property || 'unknown';
+    const propertyData = window.currentModalContext?.propertyData;
+    const constraints = extractRegexConstraints(property, propertyData);
+    const validationResult = validateStringValue(newValue, constraints);
+    
+    // Show enhanced validation result with suggestions
+    if (validationContainer) {
+        createValidationUI(validationContainer, newValue, constraints, (suggestedValue) => {
+            editor.value = suggestedValue;
+            window.updateStringValue(); // Re-validate with new value
+        });
+    }
+    
+    // Enable/disable confirm button based on validation
+    const confirmBtn = document.getElementById('confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = !validationResult.isValid;
+    }
+    
+    // Update validation status display
+    const validationStatus = document.querySelector('.validation-status');
+    if (validationStatus) {
+        validationStatus.className = `validation-status ${validationResult.isValid ? 'valid' : 'invalid'}`;
+        validationStatus.innerHTML = `
+            <span class="status-icon">${validationResult.isValid ? '✓' : '✗'}</span>
+            <span class="status-text">${validationResult.message}</span>
+        `;
+    }
+    
+    // Store updated value in modal context
+    if (window.currentModalContext) {
+        window.currentModalContext.currentValue = newValue;
+    }
+};
+
+window.confirmStringValue = function() {
+    if (!window.currentModalContext) {
+        console.error('No modal context available for string confirmation');
+        return;
+    }
+    
+    const currentValue = window.currentModalContext.currentValue || window.currentModalContext.originalValue;
+    
+    // Validate before confirming
+    const property = window.currentModalContext.property;
+    const propertyData = window.currentModalContext.propertyData;
+    const constraints = extractRegexConstraints(property, propertyData);
+    const validation = validateStringValue(currentValue, constraints);
+    
+    if (!validation.isValid) {
+        console.warn('Attempting to confirm invalid string value:', currentValue);
+        return;
+    }
+    
+    console.log('Confirm string value:', currentValue);
+    
+    // Call appropriate confirmation handler
+    if (typeof window.confirmCustomValue === 'function') {
+        window.confirmCustomValue();
+    } else if (typeof window.closeReconciliationModal === 'function') {
+        window.closeReconciliationModal();
+    }
+};

--- a/src/js/reconciliation/ui/modals/wikidata-item-modal.js
+++ b/src/js/reconciliation/ui/modals/wikidata-item-modal.js
@@ -71,14 +71,11 @@ export function createWikidataItemModal(itemId, property, valueIndex, value, pro
             <!-- Alternative Actions -->
             <div class="alternative-actions">
                 <button class="btn btn-outline" onclick="createNewWikidataItem()">Create New Item</button>
-                <button class="btn btn-outline" onclick="skipWikidataReconciliation()">Skip This Value</button>
-                <button class="btn btn-outline" onclick="useAsLiteralString()">Use as Text Instead</button>
             </div>
         </div>
 
         <div class="modal-actions">
             <button class="btn btn-secondary" onclick="closeReconciliationModal()">Cancel</button>
-            <button class="btn btn-primary" id="confirm-btn" onclick="confirmWikidataSelection()" disabled>Confirm</button>
         </div>
     `;
 
@@ -146,7 +143,7 @@ export async function loadWikidataItemMatches(value, existingMatches = null) {
             const highConfidenceMatch = matches.find(match => match.score >= 90);
             if (highConfidenceMatch) {
                 setTimeout(() => {
-                    applyWikidataMatchDirectly(highConfidenceMatch.id);
+                    applyMatchDirectly(highConfidenceMatch.id);
                 }, 100);
             }
             
@@ -210,7 +207,7 @@ export function createWikidataMatchItem(match) {
     const jsEscapedId = match.id.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
     
     return `
-        <div class="wikidata-match-item" data-match-id="${safeMatchId}" onclick="applyWikidataMatchDirectly('${jsEscapedId}')">
+        <div class="match-item" data-match-id="${safeMatchId}" onclick="applyMatchDirectly('${jsEscapedId}')">
             <div class="match-content">
                 <div class="match-label">${escapeHtml(match.label || 'Unnamed')}</div>
                 <div class="match-id">
@@ -262,38 +259,7 @@ window.performWikidataEntitySearch = async function() {
     }
 };
 
-window.applyWikidataMatchDirectly = function(matchId) {
-    // Get match details first
-    const escapedId = CSS.escape ? CSS.escape(matchId) : matchId.replace(/(["\\\n\r\t])/g, '\\$1');
-    const matchElement = document.querySelector(`[data-match-id="${escapedId}"]`);
-    
-    if (!matchElement) {
-        console.error('Wikidata match element not found for ID:', matchId);
-        return;
-    }
-    
-    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 'Unknown';
-    const matchDescription = matchElement.querySelector('.match-description')?.textContent || 'No description';
-    
-    // Store selected match globally
-    window.selectedMatch = {
-        id: matchId,
-        label: matchLabel,
-        description: matchDescription
-    };
-    
-    // Enable confirm button
-    const confirmBtn = document.getElementById('confirm-btn');
-    if (confirmBtn) {
-        confirmBtn.disabled = false;
-    }
-    
-    // Visual feedback - highlight selected match
-    document.querySelectorAll('.wikidata-match-item').forEach(item => {
-        item.classList.remove('selected');
-    });
-    matchElement.classList.add('selected');
-};
+// Note: applyMatchDirectly function is provided by reconciliation-modal.js
 
 window.showAllWikidataMatches = async function() {
     const value = window.currentModalContext?.originalValue;
@@ -349,16 +315,3 @@ window.confirmWikidataSelection = function() {
     }
 };
 
-window.skipWikidataReconciliation = function() {
-    console.log('Skip Wikidata reconciliation');
-    if (typeof window.closeReconciliationModal === 'function') {
-        window.closeReconciliationModal();
-    }
-};
-
-window.useAsLiteralString = function() {
-    console.log('Use as literal string instead of Wikidata item');
-    if (typeof window.closeReconciliationModal === 'function') {
-        window.closeReconciliationModal();
-    }
-};

--- a/src/js/reconciliation/ui/modals/wikidata-item-modal.js
+++ b/src/js/reconciliation/ui/modals/wikidata-item-modal.js
@@ -267,15 +267,12 @@ window.performWikidataEntitySearch = async function() {
  */
 function ensureWikidataModalContext() {
     if (!window.currentModalContext) {
-        console.warn('⚠️ Missing Wikidata modal context, attempting emergency reconstruction...');
-        
         // Try to reconstruct context from modal DOM
         const modalContainer = document.querySelector('.reconciliation-modal-redesign') ||
                              document.querySelector('.wikidata-item-modal') ||
                              document.querySelector('[data-modal-type]');
         
         if (modalContainer && modalContainer.dataset) {
-            console.log('🔄 Reconstructing Wikidata context from modal DOM...');
             const dataset = modalContainer.dataset;
             window.currentModalContext = {
                 itemId: dataset.itemId,
@@ -287,10 +284,8 @@ function ensureWikidataModalContext() {
                 dataType: 'wikibase-item',
                 modalType: 'wikidata-item'
             };
-            console.log('✅ Emergency Wikidata context reconstructed:', window.currentModalContext);
             return true;
         } else {
-            console.error('❌ Cannot reconstruct Wikidata context - no modal container with dataset found');
             return false;
         }
     }
@@ -298,33 +293,16 @@ function ensureWikidataModalContext() {
 }
 
 window.applyWikidataMatchDirectly = function(matchId) {
-    console.log('🔄 applyWikidataMatchDirectly called with matchId:', matchId);
-    console.log('🔍 Current window.currentModalContext:', window.currentModalContext);
-    
-    // EMERGENCY CONTEXT CHECK - ensure context is available
+    // Ensure context is available
     if (!ensureWikidataModalContext()) {
-        console.error('❌ Failed to ensure Wikidata modal context, cannot proceed');
         return;
     }
     
-    console.log('🔍 Available global functions:', {
-        selectMatchAndAdvance: typeof window.selectMatchAndAdvance,
-        markCellAsReconciled: typeof window.markCellAsReconciled,
-        closeReconciliationModal: typeof window.closeReconciliationModal,
-        confirmReconciliation: typeof window.confirmReconciliation
-    });
-    
-    // Get match details first
+    // Get match details from DOM
     const escapedId = CSS.escape ? CSS.escape(matchId) : matchId.replace(/(["\\\n\r\t])/g, '\\$1');
-    console.log('🔍 Searching for Wikidata element with data-match-id:', escapedId);
-    
     const matchElement = document.querySelector(`[data-match-id="${escapedId}"]`);
-    console.log('🔍 Found Wikidata match element:', matchElement);
     
     if (!matchElement) {
-        console.error('❌ Wikidata match element not found for ID:', matchId);
-        console.log('🔍 Available Wikidata elements with data-match-id:', 
-            Array.from(document.querySelectorAll('[data-match-id]')).map(el => el.dataset.matchId));
         return;
     }
     
@@ -332,31 +310,22 @@ window.applyWikidataMatchDirectly = function(matchId) {
     const matchLabelElement = matchElement.querySelector('.match-label') || matchElement.querySelector('.match-name');
     const matchDescriptionElement = matchElement.querySelector('.match-description');
     
-    console.log('🔍 Found Wikidata label element:', matchLabelElement);
-    console.log('🔍 Found Wikidata description element:', matchDescriptionElement);
-    
     const matchLabel = matchLabelElement?.textContent || 'Unknown';
     const matchDescription = matchDescriptionElement?.textContent || 'No description';
     
-    console.log('📝 Extracted Wikidata match data:', { id: matchId, label: matchLabel, description: matchDescription });
-    
-    // CHANGED: Instead of just storing and enabling confirm button, directly apply the match
+    // Directly apply the match instead of just storing and enabling confirm button
     if (typeof window.selectMatchAndAdvance === 'function') {
-        console.log('✅ Using selectMatchAndAdvance function for Wikidata match');
         window.selectMatchAndAdvance(matchId);
     } else if (typeof window.markCellAsReconciled === 'function' && window.currentModalContext) {
-        console.log('✅ Using markCellAsReconciled function for Wikidata match');
         window.markCellAsReconciled(window.currentModalContext, {
             type: 'wikidata',
             id: matchId,
             label: matchLabel,
             description: matchDescription
         });
-        console.log('🔄 Calling closeReconciliationModal for Wikidata match');
         window.closeReconciliationModal();
     } else {
-        console.warn('⚠️ No proper reconciliation handlers available for Wikidata match, falling back to old behavior');
-        // Store selected match globally (legacy behavior)
+        // Fallback to legacy behavior
         window.selectedMatch = {
             id: matchId,
             label: matchLabel,
@@ -374,8 +343,6 @@ window.applyWikidataMatchDirectly = function(matchId) {
             item.classList.remove('selected');
         });
         matchElement.classList.add('selected');
-        
-        console.log('🔄 Stored selectedMatch and enabled confirm button (legacy)');
     }
 };
 

--- a/src/js/reconciliation/ui/modals/wikidata-item-modal.js
+++ b/src/js/reconciliation/ui/modals/wikidata-item-modal.js
@@ -1,0 +1,364 @@
+/**
+ * Wikidata Item Reconciliation Modal
+ * @module reconciliation/ui/modals/wikidata-item-modal
+ * 
+ * Specialized modal interface for reconciling values to Wikidata entities (Q-IDs).
+ * Handles entity search, match scoring, and entity selection workflow.
+ * 
+ * Features:
+ * - Automatic entity matching via Wikidata API
+ * - Manual entity search with live results
+ * - Match confidence scoring and display
+ * - High-confidence auto-selection (≥90%)
+ * - Alternative actions (create new item, skip, etc.)
+ */
+
+/**
+ * Create Wikidata Item reconciliation modal content
+ * @param {string} itemId - Item ID being reconciled
+ * @param {string} property - Property name being reconciled
+ * @param {number} valueIndex - Index of value within property
+ * @param {string} value - The value to reconcile
+ * @param {Object} propertyData - Property metadata and constraints
+ * @param {Array} existingMatches - Pre-existing matches if available
+ * @returns {HTMLElement} Modal content element
+ */
+export function createWikidataItemModal(itemId, property, valueIndex, value, propertyData = null, existingMatches = null) {
+    const modalContent = document.createElement('div');
+    modalContent.className = 'wikidata-item-modal';
+    
+    // Store context for modal interactions
+    modalContent.dataset.modalType = 'wikidata-item';
+    modalContent.dataset.itemId = itemId;
+    modalContent.dataset.property = property;
+    modalContent.dataset.valueIndex = valueIndex;
+    modalContent.dataset.value = value;
+    if (propertyData) {
+        modalContent.dataset.propertyData = JSON.stringify(propertyData);
+    }
+    
+    modalContent.innerHTML = `
+        <div class="modal-header">
+            <div class="data-type-indicator">
+                <span class="data-type-label">Expected:</span>
+                <span class="data-type-value">Wikidata Item</span>
+            </div>
+        </div>
+
+        <div class="value-display">
+            <div class="section-title">Omeka S Value</div>
+            <div class="original-value">${escapeHtml(value)}</div>
+        </div>
+
+        <div class="wikidata-item-section">
+            <!-- Existing Matches -->
+            <div class="existing-matches" id="existing-matches">
+                <div class="section-title">Existing Matches</div>
+                <div class="loading-indicator">Finding matches...</div>
+            </div>
+
+            <!-- Manual Search -->
+            <div class="manual-search">
+                <div class="section-title">Search Wikidata</div>
+                <div class="search-container">
+                    <input type="text" id="wikidata-search" class="search-input" 
+                           placeholder="Search for a different item..." value="${escapeHtml(value)}">
+                    <button class="btn btn-primary" onclick="performWikidataEntitySearch()">Search</button>
+                </div>
+                <div class="search-results" id="search-results"></div>
+            </div>
+
+            <!-- Alternative Actions -->
+            <div class="alternative-actions">
+                <button class="btn btn-outline" onclick="createNewWikidataItem()">Create New Item</button>
+                <button class="btn btn-outline" onclick="skipWikidataReconciliation()">Skip This Value</button>
+                <button class="btn btn-outline" onclick="useAsLiteralString()">Use as Text Instead</button>
+            </div>
+        </div>
+
+        <div class="modal-actions">
+            <button class="btn btn-secondary" onclick="closeReconciliationModal()">Cancel</button>
+            <button class="btn btn-primary" id="confirm-btn" onclick="confirmWikidataSelection()" disabled>Confirm</button>
+        </div>
+    `;
+
+    return modalContent;
+}
+
+/**
+ * Initialize Wikidata item modal after DOM insertion
+ * @param {HTMLElement} modalElement - The modal element
+ */
+export function initializeWikidataItemModal(modalElement) {
+    const value = modalElement.dataset.value;
+    const existingMatches = modalElement.dataset.existingMatches ? 
+        JSON.parse(modalElement.dataset.existingMatches) : null;
+    
+    // Store modal context globally for interaction handlers
+    window.currentModalContext = {
+        itemId: modalElement.dataset.itemId,
+        property: modalElement.dataset.property,
+        valueIndex: parseInt(modalElement.dataset.valueIndex),
+        originalValue: value,
+        currentValue: value,
+        propertyData: modalElement.dataset.propertyData ? 
+            JSON.parse(modalElement.dataset.propertyData) : null,
+        dataType: 'wikibase-item',
+        existingMatches: existingMatches,
+        modalType: 'wikidata-item'
+    };
+    
+    // Load existing matches for Wikidata items
+    loadWikidataItemMatches(value, existingMatches);
+}
+
+/**
+ * Load existing matches for Wikidata items
+ * @param {string} value - Value to search for
+ * @param {Array} existingMatches - Pre-existing matches if available
+ */
+export async function loadWikidataItemMatches(value, existingMatches = null) {
+    const matchesContainer = document.getElementById('existing-matches');
+    if (!matchesContainer) return;
+    
+    try {
+        let matches = existingMatches;
+        
+        // If no existing matches provided, search for new ones
+        if (!matches || matches.length === 0) {
+            matches = await searchWikidataEntities(value);
+        }
+        
+        if (matches && matches.length > 0) {
+            const topMatches = matches.slice(0, 3); // Show top 3 matches
+            
+            matchesContainer.innerHTML = `
+                <div class="section-title">Existing Matches</div>
+                <div class="matches-list">
+                    ${topMatches.map(match => createWikidataMatchItem(match)).join('')}
+                </div>
+                ${matches.length > 3 ? `
+                    <button class="btn btn-link" onclick="showAllWikidataMatches()">Show all ${matches.length} matches</button>
+                ` : ''}
+            `;
+            
+            // Auto-select high-confidence matches (≥90%)
+            const highConfidenceMatch = matches.find(match => match.score >= 90);
+            if (highConfidenceMatch) {
+                setTimeout(() => {
+                    applyWikidataMatchDirectly(highConfidenceMatch.id);
+                }, 100);
+            }
+            
+        } else {
+            matchesContainer.innerHTML = `
+                <div class="section-title">Existing Matches</div>
+                <div class="no-matches">No automatic matches found</div>
+            `;
+        }
+    } catch (error) {
+        console.error('Error loading Wikidata matches:', error);
+        matchesContainer.innerHTML = `
+            <div class="section-title">Existing Matches</div>
+            <div class="error-message">Error loading matches</div>
+        `;
+    }
+}
+
+/**
+ * Search Wikidata entities using the API
+ * @param {string} query - Search query
+ * @returns {Promise<Array>} Array of match objects
+ */
+export async function searchWikidataEntities(query) {
+    try {
+        const apiUrl = `https://www.wikidata.org/w/api.php?action=wbsearchentities&search=${encodeURIComponent(query)}&language=en&format=json&origin=*&type=item&limit=10`;
+        
+        const response = await fetch(apiUrl);
+        if (!response.ok) {
+            throw new Error(`Wikidata API error: ${response.status}`);
+        }
+        
+        const data = await response.json();
+        
+        if (!data.search || data.search.length === 0) {
+            return [];
+        }
+        
+        // Return simple format: id, label, description
+        return data.search.map(result => ({
+            id: result.id,
+            label: result.label || result.id,
+            description: result.description || ''
+        }));
+        
+    } catch (error) {
+        console.error('Wikidata entity search failed:', error);
+        return [];
+    }
+}
+
+/**
+ * Create Wikidata match item HTML
+ * @param {Object} match - Match object with id, label, description
+ * @returns {string} HTML string for match item
+ */
+export function createWikidataMatchItem(match) {
+    // Escape match.id for safe use in HTML attributes
+    const safeMatchId = escapeHtml(match.id);
+    // Escape match.id for safe use in JavaScript string literals
+    const jsEscapedId = match.id.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
+    
+    return `
+        <div class="wikidata-match-item" data-match-id="${safeMatchId}" onclick="applyWikidataMatchDirectly('${jsEscapedId}')">
+            <div class="match-content">
+                <div class="match-label">${escapeHtml(match.label || 'Unnamed')}</div>
+                <div class="match-id">
+                    <a href="https://www.wikidata.org/wiki/${safeMatchId}" target="_blank" onclick="event.stopPropagation()">${safeMatchId}</a>
+                </div>
+                <div class="match-description">${escapeHtml(match.description || 'No description')}</div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * Escape HTML to prevent XSS
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// Global interaction handlers for Wikidata item modal
+window.performWikidataEntitySearch = async function() {
+    const searchInput = document.getElementById('wikidata-search');
+    const resultsContainer = document.getElementById('search-results');
+    
+    if (!searchInput || !resultsContainer) return;
+    
+    const query = searchInput.value.trim();
+    if (!query) return;
+    
+    resultsContainer.innerHTML = '<div class="loading">Searching...</div>';
+    
+    try {
+        const matches = await searchWikidataEntities(query);
+        
+        if (matches && matches.length > 0) {
+            resultsContainer.innerHTML = `
+                <div class="search-matches">
+                    ${matches.slice(0, 5).map(match => createWikidataMatchItem(match)).join('')}
+                </div>
+            `;
+        } else {
+            resultsContainer.innerHTML = '<div class="no-results">No results found</div>';
+        }
+    } catch (error) {
+        resultsContainer.innerHTML = '<div class="error">Search failed</div>';
+    }
+};
+
+window.applyWikidataMatchDirectly = function(matchId) {
+    // Get match details first
+    const escapedId = CSS.escape ? CSS.escape(matchId) : matchId.replace(/(["\\\n\r\t])/g, '\\$1');
+    const matchElement = document.querySelector(`[data-match-id="${escapedId}"]`);
+    
+    if (!matchElement) {
+        console.error('Wikidata match element not found for ID:', matchId);
+        return;
+    }
+    
+    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 'Unknown';
+    const matchDescription = matchElement.querySelector('.match-description')?.textContent || 'No description';
+    
+    // Store selected match globally
+    window.selectedMatch = {
+        id: matchId,
+        label: matchLabel,
+        description: matchDescription
+    };
+    
+    // Enable confirm button
+    const confirmBtn = document.getElementById('confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = false;
+    }
+    
+    // Visual feedback - highlight selected match
+    document.querySelectorAll('.wikidata-match-item').forEach(item => {
+        item.classList.remove('selected');
+    });
+    matchElement.classList.add('selected');
+};
+
+window.showAllWikidataMatches = async function() {
+    const value = window.currentModalContext?.originalValue;
+    if (!value) return;
+    
+    const matchesContainer = document.getElementById('existing-matches');
+    if (!matchesContainer) return;
+    
+    try {
+        let matches = window.currentModalContext?.existingMatches;
+        
+        // If no existing matches, search for new ones
+        if (!matches || matches.length === 0) {
+            matches = await searchWikidataEntities(value);
+        }
+        
+        if (matches && matches.length > 0) {
+            matchesContainer.innerHTML = `
+                <div class="section-title">All Matches</div>
+                <div class="matches-list">
+                    ${matches.map(match => createWikidataMatchItem(match)).join('')}
+                </div>
+                <button class="btn btn-link" onclick="showTopWikidataMatches()">Show fewer matches</button>
+            `;
+        }
+    } catch (error) {
+        console.error('Error showing all Wikidata matches:', error);
+    }
+};
+
+window.showTopWikidataMatches = function() {
+    const value = window.currentModalContext?.originalValue;
+    if (value) {
+        const existingMatches = window.currentModalContext?.existingMatches;
+        loadWikidataItemMatches(value, existingMatches);
+    }
+};
+
+window.confirmWikidataSelection = function() {
+    if (!window.currentModalContext || !window.selectedMatch) {
+        console.error('No Wikidata match selected');
+        return;
+    }
+    
+    // Call the global selectMatchAndAdvance function that should be set up by the reconciliation system
+    if (typeof window.selectMatchAndAdvance === 'function') {
+        window.selectMatchAndAdvance(window.selectedMatch.id);
+    } else {
+        console.log('Confirm Wikidata selection:', window.selectedMatch);
+        if (typeof window.closeReconciliationModal === 'function') {
+            window.closeReconciliationModal();
+        }
+    }
+};
+
+window.skipWikidataReconciliation = function() {
+    console.log('Skip Wikidata reconciliation');
+    if (typeof window.closeReconciliationModal === 'function') {
+        window.closeReconciliationModal();
+    }
+};
+
+window.useAsLiteralString = function() {
+    console.log('Use as literal string instead of Wikidata item');
+    if (typeof window.closeReconciliationModal === 'function') {
+        window.closeReconciliationModal();
+    }
+};

--- a/src/js/reconciliation/ui/modals/wikidata-item-modal.js
+++ b/src/js/reconciliation/ui/modals/wikidata-item-modal.js
@@ -71,11 +71,14 @@ export function createWikidataItemModal(itemId, property, valueIndex, value, pro
             <!-- Alternative Actions -->
             <div class="alternative-actions">
                 <button class="btn btn-outline" onclick="createNewWikidataItem()">Create New Item</button>
+                <button class="btn btn-outline" onclick="skipWikidataReconciliation()">Skip This Value</button>
+                <button class="btn btn-outline" onclick="useAsLiteralString()">Use as Text Instead</button>
             </div>
         </div>
 
         <div class="modal-actions">
             <button class="btn btn-secondary" onclick="closeReconciliationModal()">Cancel</button>
+            <button class="btn btn-primary" id="confirm-btn" onclick="confirmWikidataSelection()" disabled>Confirm</button>
         </div>
     `;
 
@@ -143,7 +146,7 @@ export async function loadWikidataItemMatches(value, existingMatches = null) {
             const highConfidenceMatch = matches.find(match => match.score >= 90);
             if (highConfidenceMatch) {
                 setTimeout(() => {
-                    applyMatchDirectly(highConfidenceMatch.id);
+                    applyWikidataMatchDirectly(highConfidenceMatch.id);
                 }, 100);
             }
             
@@ -207,7 +210,7 @@ export function createWikidataMatchItem(match) {
     const jsEscapedId = match.id.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
     
     return `
-        <div class="match-item" data-match-id="${safeMatchId}" onclick="applyMatchDirectly('${jsEscapedId}')">
+        <div class="wikidata-match-item" data-match-id="${safeMatchId}" onclick="applyWikidataMatchDirectly('${jsEscapedId}')">
             <div class="match-content">
                 <div class="match-label">${escapeHtml(match.label || 'Unnamed')}</div>
                 <div class="match-id">
@@ -259,7 +262,38 @@ window.performWikidataEntitySearch = async function() {
     }
 };
 
-// Note: applyMatchDirectly function is provided by reconciliation-modal.js
+window.applyWikidataMatchDirectly = function(matchId) {
+    // Get match details first
+    const escapedId = CSS.escape ? CSS.escape(matchId) : matchId.replace(/(["\\\n\r\t])/g, '\\$1');
+    const matchElement = document.querySelector(`[data-match-id="${escapedId}"]`);
+    
+    if (!matchElement) {
+        console.error('Wikidata match element not found for ID:', matchId);
+        return;
+    }
+    
+    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 'Unknown';
+    const matchDescription = matchElement.querySelector('.match-description')?.textContent || 'No description';
+    
+    // Store selected match globally
+    window.selectedMatch = {
+        id: matchId,
+        label: matchLabel,
+        description: matchDescription
+    };
+    
+    // Enable confirm button
+    const confirmBtn = document.getElementById('confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = false;
+    }
+    
+    // Visual feedback - highlight selected match
+    document.querySelectorAll('.wikidata-match-item').forEach(item => {
+        item.classList.remove('selected');
+    });
+    matchElement.classList.add('selected');
+};
 
 window.showAllWikidataMatches = async function() {
     const value = window.currentModalContext?.originalValue;
@@ -315,3 +349,16 @@ window.confirmWikidataSelection = function() {
     }
 };
 
+window.skipWikidataReconciliation = function() {
+    console.log('Skip Wikidata reconciliation');
+    if (typeof window.closeReconciliationModal === 'function') {
+        window.closeReconciliationModal();
+    }
+};
+
+window.useAsLiteralString = function() {
+    console.log('Use as literal string instead of Wikidata item');
+    if (typeof window.closeReconciliationModal === 'function') {
+        window.closeReconciliationModal();
+    }
+};

--- a/src/js/reconciliation/ui/modals/wikidata-item-modal.js
+++ b/src/js/reconciliation/ui/modals/wikidata-item-modal.js
@@ -262,9 +262,51 @@ window.performWikidataEntitySearch = async function() {
     }
 };
 
+/**
+ * Emergency context reconstruction for Wikidata modal if context is missing
+ */
+function ensureWikidataModalContext() {
+    if (!window.currentModalContext) {
+        console.warn('⚠️ Missing Wikidata modal context, attempting emergency reconstruction...');
+        
+        // Try to reconstruct context from modal DOM
+        const modalContainer = document.querySelector('.reconciliation-modal-redesign') ||
+                             document.querySelector('.wikidata-item-modal') ||
+                             document.querySelector('[data-modal-type]');
+        
+        if (modalContainer && modalContainer.dataset) {
+            console.log('🔄 Reconstructing Wikidata context from modal DOM...');
+            const dataset = modalContainer.dataset;
+            window.currentModalContext = {
+                itemId: dataset.itemId,
+                property: dataset.property,
+                valueIndex: dataset.valueIndex ? parseInt(dataset.valueIndex) : 0,
+                originalValue: dataset.value,
+                currentValue: dataset.value,
+                propertyData: dataset.propertyData ? JSON.parse(dataset.propertyData) : null,
+                dataType: 'wikibase-item',
+                modalType: 'wikidata-item'
+            };
+            console.log('✅ Emergency Wikidata context reconstructed:', window.currentModalContext);
+            return true;
+        } else {
+            console.error('❌ Cannot reconstruct Wikidata context - no modal container with dataset found');
+            return false;
+        }
+    }
+    return true; // Context already exists
+}
+
 window.applyWikidataMatchDirectly = function(matchId) {
     console.log('🔄 applyWikidataMatchDirectly called with matchId:', matchId);
     console.log('🔍 Current window.currentModalContext:', window.currentModalContext);
+    
+    // EMERGENCY CONTEXT CHECK - ensure context is available
+    if (!ensureWikidataModalContext()) {
+        console.error('❌ Failed to ensure Wikidata modal context, cannot proceed');
+        return;
+    }
+    
     console.log('🔍 Available global functions:', {
         selectMatchAndAdvance: typeof window.selectMatchAndAdvance,
         markCellAsReconciled: typeof window.markCellAsReconciled,

--- a/src/js/reconciliation/ui/reconciliation-modal.js
+++ b/src/js/reconciliation/ui/reconciliation-modal.js
@@ -519,9 +519,7 @@ window.applyMatchDirectly = function(matchId) {
         return;
     }
     
-    // Try both class names for compatibility between old and new systems
-    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 
-                      matchElement.querySelector('.match-name')?.textContent || 'Unknown';
+    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 'Unknown';
     const matchDescription = matchElement.querySelector('.match-description')?.textContent || 'No description';
     
     // Check if we have the proper handler functions available
@@ -627,25 +625,17 @@ export function createOpenReconciliationModalFactory(dependencies) {
                 setupDynamicDatePrecision(modalContent);
                 setupAutoAdvanceToggle();
                 
-                // Initialize modal using the factory system
+                // Initialize modal interactions using stored data
                 const modalContainer = document.querySelector('.reconciliation-modal-redesign');
                 if (modalContainer) {
-                    try {
-                        // Use the proper factory initialization instead of deprecated function
-                        initializeReconciliationModal(modalContainer);
-                        console.log('Modal initialized successfully using factory system');
-                    } catch (error) {
-                        console.error('Error initializing modal with factory system:', error);
-                        // Fallback to deprecated system
-                        const dataType = modalContainer.dataset.dataType;
-                        const value = modalContainer.dataset.value;
-                        const property = modalContainer.dataset.property;
-                        const propertyData = modalContainer.dataset.propertyData ? 
-                            JSON.parse(modalContainer.dataset.propertyData) : null;
-                        
-                        if (dataType && value) {
-                            initializeModalInteractions(dataType, value, property, propertyData);
-                        }
+                    const dataType = modalContainer.dataset.initDataType;
+                    const value = modalContainer.dataset.initValue;
+                    const property = modalContainer.dataset.initProperty;
+                    const propertyData = modalContainer.dataset.initPropertyData ? 
+                        JSON.parse(modalContainer.dataset.initPropertyData) : null;
+                    
+                    if (dataType && value) {
+                        initializeModalInteractions(dataType, value, property, propertyData);
                     }
                 }
             }

--- a/src/js/reconciliation/ui/reconciliation-modal.js
+++ b/src/js/reconciliation/ui/reconciliation-modal.js
@@ -519,7 +519,9 @@ window.applyMatchDirectly = function(matchId) {
         return;
     }
     
-    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 'Unknown';
+    // Try both class names for compatibility between old and new systems
+    const matchLabel = matchElement.querySelector('.match-label')?.textContent || 
+                      matchElement.querySelector('.match-name')?.textContent || 'Unknown';
     const matchDescription = matchElement.querySelector('.match-description')?.textContent || 'No description';
     
     // Check if we have the proper handler functions available
@@ -625,17 +627,25 @@ export function createOpenReconciliationModalFactory(dependencies) {
                 setupDynamicDatePrecision(modalContent);
                 setupAutoAdvanceToggle();
                 
-                // Initialize modal interactions using stored data
+                // Initialize modal using the factory system
                 const modalContainer = document.querySelector('.reconciliation-modal-redesign');
                 if (modalContainer) {
-                    const dataType = modalContainer.dataset.initDataType;
-                    const value = modalContainer.dataset.initValue;
-                    const property = modalContainer.dataset.initProperty;
-                    const propertyData = modalContainer.dataset.initPropertyData ? 
-                        JSON.parse(modalContainer.dataset.initPropertyData) : null;
-                    
-                    if (dataType && value) {
-                        initializeModalInteractions(dataType, value, property, propertyData);
+                    try {
+                        // Use the proper factory initialization instead of deprecated function
+                        initializeReconciliationModal(modalContainer);
+                        console.log('Modal initialized successfully using factory system');
+                    } catch (error) {
+                        console.error('Error initializing modal with factory system:', error);
+                        // Fallback to deprecated system
+                        const dataType = modalContainer.dataset.dataType;
+                        const value = modalContainer.dataset.value;
+                        const property = modalContainer.dataset.property;
+                        const propertyData = modalContainer.dataset.propertyData ? 
+                            JSON.parse(modalContainer.dataset.propertyData) : null;
+                        
+                        if (dataType && value) {
+                            initializeModalInteractions(dataType, value, property, propertyData);
+                        }
                     }
                 }
             }

--- a/src/js/reconciliation/ui/reconciliation-modal.js
+++ b/src/js/reconciliation/ui/reconciliation-modal.js
@@ -865,7 +865,7 @@ export function createOpenReconciliationModalFactory(dependencies) {
         }, 100);
         
         // Start automatic reconciliation for Wikidata items
-        const dataType = getDataTypeFromProperty(property, manualProp?.property);
+        // Note: dataType already declared above, reusing it
         if (dataType === 'wikibase-item') {
             await performAutomaticReconciliation(value, property, itemId, valueIndex);
         }

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -532,6 +532,9 @@ export function setupReconciliationStep(state) {
     });
     
     // Expose modal interaction handlers to global scope for HTML onclick handlers
+    console.log('🔄 Setting up global reconciliation functions...');
+    console.log('🔍 modalInteractionHandlers available:', modalInteractionHandlers);
+    
     window.toggleMoreOptions = modalInteractionHandlers.toggleMoreOptions;
     window.selectMatchAndAdvance = modalInteractionHandlers.selectMatchAndAdvance;
     window.confirmCustomValue = modalInteractionHandlers.confirmCustomValue;
@@ -544,6 +547,15 @@ export function setupReconciliationStep(state) {
     
     // Also expose modalUI to global scope for modal closing
     window.modalUI = modalUI;
+    
+    console.log('✅ Global reconciliation functions set up:', {
+        selectMatchAndAdvance: typeof window.selectMatchAndAdvance,
+        modalUI: typeof window.modalUI,
+        markCellAsReconciled: typeof modules.markCellAsReconciled
+    });
+    
+    // Also expose markCellAsReconciled for direct access
+    window.markCellAsReconciled = modules.markCellAsReconciled;
     
     window.applyTypeOverride = modalInteractionHandlers.applyTypeOverride;
     window.confirmReconciliation = modalInteractionHandlers.confirmReconciliation; // Legacy

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -532,9 +532,6 @@ export function setupReconciliationStep(state) {
     });
     
     // Expose modal interaction handlers to global scope for HTML onclick handlers
-    console.log('🔄 Setting up global reconciliation functions...');
-    console.log('🔍 modalInteractionHandlers available:', modalInteractionHandlers);
-    
     window.toggleMoreOptions = modalInteractionHandlers.toggleMoreOptions;
     window.selectMatchAndAdvance = modalInteractionHandlers.selectMatchAndAdvance;
     window.confirmCustomValue = modalInteractionHandlers.confirmCustomValue;
@@ -547,12 +544,6 @@ export function setupReconciliationStep(state) {
     
     // Also expose modalUI to global scope for modal closing
     window.modalUI = modalUI;
-    
-    console.log('✅ Global reconciliation functions set up:', {
-        selectMatchAndAdvance: typeof window.selectMatchAndAdvance,
-        modalUI: typeof window.modalUI,
-        markCellAsReconciled: typeof modules.markCellAsReconciled
-    });
     
     // Also expose markCellAsReconciled for direct access
     window.markCellAsReconciled = modules.markCellAsReconciled;


### PR DESCRIPTION
## Summary

Fixes critical issue where clicking on reconciliation suggestions in the modal had no effect, preventing users from applying Wikidata matches.

## Problem Description

- Users could see reconciliation suggestions (both existing matches and search results) in the modal
- Clicking on any suggestion did nothing - no reconciliation was applied, modal didn't close
- Root cause: `window.currentModalContext` was undefined when `selectMatchAndAdvance` was called
- Additional issues: inconsistent HTML selectors between existing matches (`.match-name`) and search results (`.match-label`)

## Solution Implemented

### 🛡️ Multi-Layer Context Protection System

1. **Immediate Context Setup**: Context created synchronously when modal opens
2. **Emergency Context Verification**: 10ms timeout to restore context if lost  
3. **Enhanced Modal Initialization**: Robust DOM selectors with multiple fallbacks
4. **Click-Time Context Recovery**: Emergency reconstruction from modal DOM
5. **Comprehensive Error Handling**: Graceful fallbacks throughout

### 🔧 Technical Fixes

- **Fixed HTML Selector Compatibility**: Both functions now check for `.match-label` AND `.match-name`
- **Unified Click Handlers**: `applyWikidataMatchDirectly` now directly applies matches instead of just storing them
- **Enhanced Modal Factory Integration**: Proper routing through factory system with robust fallbacks
- **Global Function Chain Verification**: Ensured all required functions are properly exposed

## Files Modified

- `src/js/reconciliation/ui/reconciliation-modal.js` - Core modal functionality and context management
- `src/js/reconciliation/ui/modals/wikidata-item-modal.js` - Wikidata-specific modal handlers  
- `src/js/steps/reconciliation.js` - Global function setup and exposure

## Test Plan

**Manual Testing Required:**

- [ ] Open reconciliation step
- [ ] Click on any cell to open reconciliation modal
- [ ] Verify "Existing Matches" section shows suggestions with Q-IDs
- [ ] Click on any existing match → should immediately apply reconciliation, show Q-ID and Label in table, close modal
- [ ] Search for different term in "Search Wikidata" section  
- [ ] Click on any search result → should immediately apply reconciliation, show Q-ID and Label in table, close modal
- [ ] Test with different data types (ensure Wikidata items work correctly)
- [ ] Verify no console errors during the process

**Expected Behavior:**
- ✅ Immediate reconciliation application on click
- ✅ Clear Q-ID and Label display in reconciliation table
- ✅ Automatic modal closure after selection
- ✅ No console errors or warnings

## Production Ready

- ✅ All debugging console logs removed
- ✅ Clean, maintainable code structure
- ✅ Comprehensive error handling retained
- ✅ Multiple fallback systems for robustness

🤖 Generated with [Claude Code](https://claude.ai/code)