### PR TITLE
Add Skip button to reconciliation modals for unsuitable values

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2584,9 +2584,10 @@ pre.sample-value {
 }
 
 .property-value[data-status="skipped"] {
-    background-color: #fff3e0;
-    border-color: #ff9800;
+    background-color: #f5f5f5;
+    border-color: #bdbdbd;
     cursor: default;
+    opacity: 0.7;
 }
 
 .value-text {
@@ -2609,7 +2610,7 @@ pre.sample-value {
 }
 
 .value-status.skipped {
-    color: #f57c00;
+    color: #757575;
     font-weight: 500;
 }
 
@@ -3378,7 +3379,7 @@ pre.sample-value {
 }
 
 .value-status.skipped {
-    color: #ff9800;
+    color: #757575;
     font-style: italic;
 }
 

--- a/src/js/reconciliation/ui/modals/string-modal.js
+++ b/src/js/reconciliation/ui/modals/string-modal.js
@@ -325,7 +325,7 @@ export function createStringModal(itemId, property, valueIndex, value, propertyD
         <div class="modal-actions">
             <button class="btn btn-secondary" onclick="cancelStringModal()">Cancel</button>
             <button class="btn btn-outline" onclick="resetStringModal()">Reset</button>
-            <button class="btn btn-outline" onclick="skipStringValue()">Skip</button>
+            <button class="btn btn-outline" onclick="skipReconciliation()">Skip</button>
             <button class="btn btn-primary" id="confirm-btn" onclick="confirmStringValue()">Confirm</button>
         </div>
     `;
@@ -661,58 +661,6 @@ window.cancelStringModal = function() {
 
 window.resetStringModal = function() {
     window.resetToOriginalValue();
-};
-
-window.skipStringValue = function() {
-    if (!window.currentModalContext) {
-        console.error('No modal context available for string skip');
-        return;
-    }
-    
-    console.log('Skipping string value:', window.currentModalContext);
-    
-    // Try multiple approaches to mark the cell as skipped
-    let skipped = false;
-    
-    // First, try the proper modal interaction handler for skipping
-    if (typeof window.markCellAsSkipped === 'function') {
-        window.markCellAsSkipped(window.currentModalContext);
-        skipped = true;
-        if (typeof window.closeReconciliationModal === 'function') {
-            window.closeReconciliationModal();
-        }
-    }
-    // Try the factory-based interaction handlers
-    else if (window.modalInteractionHandlers && typeof window.modalInteractionHandlers.markCellAsSkipped === 'function') {
-        window.modalInteractionHandlers.markCellAsSkipped(window.currentModalContext);
-        skipped = true;
-        if (typeof window.closeReconciliationModal === 'function') {
-            window.closeReconciliationModal();
-        }
-    }
-    // Fallback: dispatch a custom event that other parts of the system can listen to
-    else {
-        const event = new CustomEvent('stringValueSkipped', {
-            detail: {
-                context: window.currentModalContext
-            }
-        });
-        document.dispatchEvent(event);
-        skipped = true;
-        
-        // Close modal if possible
-        if (typeof window.closeReconciliationModal === 'function') {
-            window.closeReconciliationModal();
-        }
-    }
-    
-    if (!skipped) {
-        console.warn('No skip handler found - value may not be marked as skipped');
-        // Still close the modal even if skipping failed
-        if (typeof window.closeReconciliationModal === 'function') {
-            window.closeReconciliationModal();
-        }
-    }
 };
 
 window.confirmStringValue = function() {

--- a/src/js/reconciliation/ui/modals/string-modal.js
+++ b/src/js/reconciliation/ui/modals/string-modal.js
@@ -325,6 +325,7 @@ export function createStringModal(itemId, property, valueIndex, value, propertyD
         <div class="modal-actions">
             <button class="btn btn-secondary" onclick="cancelStringModal()">Cancel</button>
             <button class="btn btn-outline" onclick="resetStringModal()">Reset</button>
+            <button class="btn btn-outline" onclick="skipStringValue()">Skip</button>
             <button class="btn btn-primary" id="confirm-btn" onclick="confirmStringValue()">Confirm</button>
         </div>
     `;
@@ -660,6 +661,58 @@ window.cancelStringModal = function() {
 
 window.resetStringModal = function() {
     window.resetToOriginalValue();
+};
+
+window.skipStringValue = function() {
+    if (!window.currentModalContext) {
+        console.error('No modal context available for string skip');
+        return;
+    }
+    
+    console.log('Skipping string value:', window.currentModalContext);
+    
+    // Try multiple approaches to mark the cell as skipped
+    let skipped = false;
+    
+    // First, try the proper modal interaction handler for skipping
+    if (typeof window.markCellAsSkipped === 'function') {
+        window.markCellAsSkipped(window.currentModalContext);
+        skipped = true;
+        if (typeof window.closeReconciliationModal === 'function') {
+            window.closeReconciliationModal();
+        }
+    }
+    // Try the factory-based interaction handlers
+    else if (window.modalInteractionHandlers && typeof window.modalInteractionHandlers.markCellAsSkipped === 'function') {
+        window.modalInteractionHandlers.markCellAsSkipped(window.currentModalContext);
+        skipped = true;
+        if (typeof window.closeReconciliationModal === 'function') {
+            window.closeReconciliationModal();
+        }
+    }
+    // Fallback: dispatch a custom event that other parts of the system can listen to
+    else {
+        const event = new CustomEvent('stringValueSkipped', {
+            detail: {
+                context: window.currentModalContext
+            }
+        });
+        document.dispatchEvent(event);
+        skipped = true;
+        
+        // Close modal if possible
+        if (typeof window.closeReconciliationModal === 'function') {
+            window.closeReconciliationModal();
+        }
+    }
+    
+    if (!skipped) {
+        console.warn('No skip handler found - value may not be marked as skipped');
+        // Still close the modal even if skipping failed
+        if (typeof window.closeReconciliationModal === 'function') {
+            window.closeReconciliationModal();
+        }
+    }
 };
 
 window.confirmStringValue = function() {

--- a/src/js/reconciliation/ui/modals/wikidata-item-modal.js
+++ b/src/js/reconciliation/ui/modals/wikidata-item-modal.js
@@ -78,6 +78,7 @@ export function createWikidataItemModal(itemId, property, valueIndex, value, pro
 
         <div class="modal-actions">
             <button class="btn btn-secondary" onclick="closeReconciliationModal()">Cancel</button>
+            <button class="btn btn-outline" onclick="skipReconciliation()">Skip</button>
             <button class="btn btn-primary" id="confirm-btn" onclick="confirmWikidataSelection()" disabled>Confirm</button>
         </div>
     `;
@@ -401,9 +402,14 @@ window.confirmWikidataSelection = function() {
 };
 
 window.skipWikidataReconciliation = function() {
-    console.log('Skip Wikidata reconciliation');
-    if (typeof window.closeReconciliationModal === 'function') {
-        window.closeReconciliationModal();
+    // Use the existing skipReconciliation function for proper state management and UI updates
+    if (typeof window.skipReconciliation === 'function') {
+        window.skipReconciliation();
+    } else {
+        console.warn('skipReconciliation function not available');
+        if (typeof window.closeReconciliationModal === 'function') {
+            window.closeReconciliationModal();
+        }
     }
 };
 


### PR DESCRIPTION
## Summary

Adds Skip buttons to both string and item reconciliation modals, allowing users to mark values as unsuitable for reconciliation. Skipped values appear grayed out in the reconciliation table and can be revisited later if needed.

## Changes Made

### String Modal (`string-modal.js`)
- ✅ Added Skip button to bottom actions area (between Reset and Confirm)
- ✅ Integrated with existing `skipReconciliation()` function for proper state management
- ✅ Skip button uses `btn-outline` styling to differentiate from primary Confirm button

### Item Modal (`wikidata-item-modal.js`) 
- ✅ Added Skip button to bottom actions area (between Cancel and Confirm)  
- ✅ Fixed `skipWikidataReconciliation()` to use existing `skipReconciliation()` function
- ✅ Both bottom actions Skip button and existing "Skip This Value" alternative action work correctly

### Visual Styling (`style.css`)
- ✅ Updated CSS for skipped values from orange/amber to gray with opacity
- ✅ Provides proper "grayed out" appearance that indicates values are unsuitable for reconciliation

## User Experience

### Before
- ❌ No Skip button in string modal bottom actions
- ❌ Item modal skip functionality didn't update UI or advance to next item
- ❌ Skipped values appeared in orange (confusing - looked like warnings)

### After  
- ✅ **Consistent Skip buttons** in bottom actions across both modal types
- ✅ **Visual feedback** - Skipped values appear grayed out in reconciliation table
- ✅ **Auto-advance** - Automatically jumps to next unprocessed reconciliation
- ✅ **Progress tracking** - Skipped values count toward reconciliation completion
- ✅ **Reversible decisions** - Users can click skipped values to change their mind

## Technical Implementation

- **Leverages existing infrastructure** - Uses proven `skipReconciliation()` function instead of custom logic
- **Consistent patterns** - Same approach across both modal types  
- **Proper integration** - Works with existing state management, progress tracking, and auto-advance
- **Graceful fallbacks** - Handles edge cases where functions might not be available

## Test Plan

- [x] Test Skip button appears in both string and item reconciliation modals
- [x] Test Skip button properly marks values as skipped with gray styling
- [x] Test auto-advance to next unprocessed reconciliation after skip
- [x] Test progress tracking counts skipped values toward completion
- [x] Test users can click skipped values to re-open and reconcile them

🤖 Generated with [Claude Code](https://claude.ai/code)