### PR TITLE
Fix reconciliation data persistence and console error

### DIFF
--- a/src/js/reconciliation/core/reconciliation-data.js
+++ b/src/js/reconciliation/core/reconciliation-data.js
@@ -247,8 +247,8 @@ export function extractPropertyValues(item, keyOrKeyObj, state = null) {
 /**
  * Combine and sort all properties (mapped and manual) to prioritize label, description, aliases, and instance of
  */
-export function combineAndSortProperties(mappedKeys) {
-    // Create array with mapped properties only
+export function combineAndSortProperties(mappedKeys, manualProperties = []) {
+    // Create array with mapped and manual properties
     const allProperties = [];
     
     // Add mapped properties with a type indicator
@@ -256,6 +256,15 @@ export function combineAndSortProperties(mappedKeys) {
         allProperties.push({
             type: 'mapped',
             data: keyObj,
+            originalIndex: index
+        });
+    });
+    
+    // Add manual properties with a type indicator
+    manualProperties.forEach((manualProp, index) => {
+        allProperties.push({
+            type: 'manual',
+            data: manualProp,
             originalIndex: index
         });
     });


### PR DESCRIPTION
## Summary
- Fixed `ReferenceError: manualProperties is not defined` console error when returning to reconciliation step
- Enhanced `combineAndSortProperties` to include manual properties from state for proper display
- Updated `restoreReconciliationDisplay` to handle manual property reconciliation data restoration
- Ensures all reconciliation work (both mapped and manual properties) persists when switching between steps

## Test plan
- [ ] Navigate through mapping → reconciliation → Wikidata Designer → reconciliation workflow
- [ ] Verify no console errors appear when returning to reconciliation step
- [ ] Confirm manual properties remain visible in reconciliation table after step changes
- [ ] Test that completed reconciliation work is preserved when switching steps
- [ ] Verify both mapped and manual property reconciliation states are properly restored

🤖 Generated with [Claude Code](https://claude.ai/code)