### PR TITLE
Remove issues section from Wikidata designer step

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4677,63 +4677,6 @@ pre.sample-value {
     color: #333;
 }
 
-/* Issues Section */
-.issues-section {
-    margin-bottom: 2rem;
-    padding: 1.5rem;
-    background-color: #fff8f8;
-    border: 1px solid var(--danger-color);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-
-.issues-section h3 {
-    color: var(--danger-color);
-    margin-bottom: 1rem;
-    font-size: 1.3rem;
-}
-
-.issues-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.issue-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem;
-    background-color: white;
-    border: 1px solid #ffcdd2;
-    border-radius: 4px;
-    font-size: 0.9rem;
-}
-
-.issue-icon {
-    color: var(--danger-color);
-    font-size: 1.1rem;
-}
-
-.issue-text {
-    flex: 1;
-    color: #666;
-}
-
-.issue-action {
-    padding: 0.3rem 0.6rem;
-    background-color: var(--danger-color);
-    color: white;
-    border: none;
-    border-radius: 3px;
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.issue-action:hover {
-    background-color: #c62828;
-}
 
 /* Placeholder styling */
 .designer-container .placeholder {

--- a/src/index.html
+++ b/src/index.html
@@ -275,13 +275,6 @@
                         </div>
                     </div>
                     
-                    <!-- Unresolved Issues Section -->
-                    <div class="issues-section" style="display: none;">
-                        <h3>Unresolved Issues</h3>
-                        <div class="issues-list" id="issues-list">
-                            <div class="placeholder">No issues detected</div>
-                        </div>
-                    </div>
                     
                     <!-- Navigation -->
                     <div class="navigation-buttons">

--- a/src/js/steps/designer.js
+++ b/src/js/steps/designer.js
@@ -196,7 +196,6 @@ export function setupDesignerStep(state) {
         initializeLanguageMappings();
         displayReferences();
         displayProperties();
-        checkForIssues();
         updateProceedButton();
         
         // Try to auto-detect references on init
@@ -3812,90 +3811,6 @@ export function setupDesignerStep(state) {
                 });
             }
         });
-    }
-    
-    // Check for issues
-    function checkForIssues() {
-        const issuesSection = document.querySelector('.issues-section');
-        const issuesList = document.getElementById('issues-list');
-        if (!issuesSection || !issuesList) {
-            console.error('Designer - issues section not found!');
-            return;
-        }
-        
-        const issues = [];
-        const currentState = state.getState();
-        const oldReferences = currentState.references || [];
-        const globalReferences = currentState.globalReferences || [];
-        const allReferences = [...oldReferences, ...globalReferences];
-        const fetchedData = currentState.fetchedData || [];
-        const reconciliationData = currentState.reconciliationData || {};
-        
-        // Ensure all properties have references arrays
-        ensureReferencesArrays(reconciliationData);
-        
-        // Check if any property has references
-        let hasAnyReferences = false;
-        for (const itemKey of Object.keys(reconciliationData)) {
-            const itemData = reconciliationData[itemKey];
-            if (itemData.properties) {
-                for (const propertyKey of Object.keys(itemData.properties)) {
-                    const propData = itemData.properties[propertyKey];
-                    if (propData.references?.length > 0) {
-                        hasAnyReferences = true;
-                        break;
-                    }
-                }
-                if (hasAnyReferences) break;
-            }
-        }
-        
-        // Also check if any global references exist (even if not applied yet)
-        if (!hasAnyReferences && allReferences.length === 0) {
-            issues.push({
-                type: 'no-references',
-                text: 'No references added. At least one reference is required.',
-                icon: '⚠️'
-            });
-        }
-        
-        // Update issues display
-        issuesList.innerHTML = '';
-        
-        if (issues.length === 0) {
-            // Hide the entire issues section when there are no issues
-            issuesSection.style.display = 'none';
-        } else {
-            // Show the issues section when there are issues
-            issuesSection.style.display = 'block';
-            
-            issues.forEach(issue => {
-                const issueItem = createElement('div', {
-                    className: 'issue-item'
-                });
-                
-                const issueIcon = createElement('span', {
-                    className: 'issue-icon'
-                }, issue.icon);
-                
-                const issueText = createElement('span', {
-                    className: 'issue-text'
-                }, issue.text);
-                
-                issueItem.appendChild(issueIcon);
-                issueItem.appendChild(issueText);
-                
-                if (issue.type === 'no-references') {
-                    const fixBtn = createButton('Add Reference', {
-                        className: 'issue-action',
-                        onClick: addManualReference
-                    });
-                    issueItem.appendChild(fixBtn);
-                }
-                
-                issuesList.appendChild(issueItem);
-            });
-        }
     }
     
     // Update preview


### PR DESCRIPTION
## Summary
- Removes the entire issues section from the Wikidata designer step interface
- Removes the `checkForIssues()` function and its call from the initialization
- Removes all related CSS styling for the issues section
- Removes the HTML markup for the issues section from the template

## Test plan
- [ ] Verify the designer step loads without errors
- [ ] Confirm the issues section is no longer visible in the UI
- [ ] Test that the designer functionality works normally without the issues validation

🤖 Generated with [Claude Code](https://claude.ai/code)