### PR TITLE
Improve Step 2 mapping workflow with quick-add buttons and required property indicators

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -112,6 +112,12 @@ button {
     flex-shrink: 0;
 }
 
+.add-label-section {
+    margin-bottom: 20px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
 /* Custom Entity Schema Selector */
 .entity-schema-selector-custom {
     position: relative;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -112,10 +112,13 @@ button {
     flex-shrink: 0;
 }
 
-.add-label-section {
+.add-metadata-section {
     margin-bottom: 20px;
     padding-bottom: 20px;
     border-bottom: 1px solid var(--border-color);
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 
 /* Custom Entity Schema Selector */

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2041,6 +2041,27 @@ pre.sample-value {
     margin-left: 0.5rem;
 }
 
+/* Required property placeholder styling */
+.required-mapping-placeholder {
+    color: var(--danger-color);
+}
+
+.required-property-name {
+    font-weight: 600;
+    color: #d32f2f;
+    font-size: 0.9rem;
+}
+
+.required-property-description {
+    font-size: 0.75rem;
+    color: #c62828;
+    font-style: italic;
+}
+
+.required-mapping-item:hover {
+    background-color: rgba(244, 67, 54, 0.05);
+}
+
 .key-list li {
     padding: 0.3rem 0.5rem;
     border-bottom: 1px solid #eee;

--- a/src/index.html
+++ b/src/index.html
@@ -113,6 +113,9 @@
                     </div>
                     <button id="add-wikidata-property" class="button button--primary">Add Wikidata Property</button>
                 </div>
+                <div class="add-label-section">
+                    <button id="add-label" class="button button--secondary">Add Label</button>
+                </div>
                 <div class="mapping-container">
                     
                     <div class="key-sections">

--- a/src/index.html
+++ b/src/index.html
@@ -113,8 +113,11 @@
                     </div>
                     <button id="add-wikidata-property" class="button button--primary">Add Wikidata Property</button>
                 </div>
-                <div class="add-label-section">
+                <div class="add-metadata-section">
                     <button id="add-label" class="button button--secondary">Add Label</button>
+                    <button id="add-description" class="button button--secondary">Add Description</button>
+                    <button id="add-aliases" class="button button--secondary">Add Aliases</button>
+                    <button id="add-instance-of" class="button button--secondary">Add Instance of</button>
                 </div>
                 <div class="mapping-container">
                     

--- a/src/index.html
+++ b/src/index.html
@@ -111,13 +111,13 @@
                     <div id="entity-schema-selector-container" class="entity-schema-selector-header">
                         <!-- Entity Schema selector will be inserted here -->
                     </div>
-                    <button id="add-wikidata-property" class="button button--primary">Add Wikidata Property</button>
                 </div>
                 <div class="add-metadata-section">
                     <button id="add-label" class="button button--secondary">Add Label</button>
                     <button id="add-description" class="button button--secondary">Add Description</button>
                     <button id="add-aliases" class="button button--secondary">Add Aliases</button>
                     <button id="add-instance-of" class="button button--secondary">Add Instance of</button>
+                    <button id="add-wikidata-property" class="button button--secondary">Add Other Wikidata Property</button>
                 </div>
                 <div class="mapping-container">
                     

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -212,95 +212,101 @@ export function setupMappingStep(state) {
         });
     }
 
+    /**
+     * Opens the mapping modal with Label pre-selected
+     * Used by both "Add Label" button and required property placeholder
+     */
+    function openModalWithLabelPreselected() {
+        // Get total items from current state for custom mappings
+        const currentState = window.mappingStepState?.getState();
+        const totalItems = currentState?.fetchedData?.length || 0;
+
+        // Create empty key data for the modal
+        const emptyKeyData = {
+            key: '',
+            type: 'unknown',
+            frequency: totalItems,
+            totalItems: totalItems,
+            sampleValue: ''
+        };
+
+        // Open the mapping modal with empty data
+        openMappingModal(emptyKeyData);
+
+        // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
+        // then set the label property
+        setTimeout(() => {
+            const labelProperty = {
+                id: 'label',
+                label: 'Labels',
+                description: 'Main name for entities',
+                datatype: 'monolingualtext',
+                datatypeLabel: 'Monolingual text',
+                isMetadata: true,
+                helpUrl: 'https://www.wikidata.org/wiki/Help:Label'
+            };
+
+            // Set the selected property
+            window.currentMappingSelectedProperty = labelProperty;
+
+            // Update UI to show selection
+            const selectedSection = document.getElementById('selected-property');
+            const selectedDetails = document.getElementById('selected-property-details');
+
+            if (selectedSection && selectedDetails) {
+                selectedSection.style.display = 'block';
+                selectedDetails.innerHTML = `
+                    <div class="property-info metadata-property-info">
+                        <h3>🏷️ ${labelProperty.label}</h3>
+                        <p class="property-id">Metadata Field</p>
+                        <p>${labelProperty.description}</p>
+                        <a href="${labelProperty.helpUrl}" target="_blank" rel="noopener">
+                            Learn more about ${labelProperty.label} →
+                        </a>
+                        <div class="metadata-notice" style="margin-top: 10px; padding: 10px; background: #fff3cd; border-radius: 5px;">
+                            <strong>Note:</strong> This is a metadata field for Wikidata entities.
+                            Values will be treated as language-specific text.
+                        </div>
+                    </div>
+                `;
+            }
+
+            // Update datatype display
+            const datatypeDisplay = document.getElementById('detected-datatype');
+            if (datatypeDisplay) {
+                datatypeDisplay.innerHTML = `
+                    <span class="datatype-label">Monolingual text</span>
+                `;
+            }
+
+            // Show datatype section
+            const datatypeSection = document.getElementById('datatype-info-section');
+            if (datatypeSection) {
+                datatypeSection.style.display = 'block';
+            }
+
+            // Highlight the Labels button if it exists
+            const labelsButton = Array.from(document.querySelectorAll('.metadata-select-button'))
+                .find(btn => btn.textContent.includes('Labels'));
+            if (labelsButton) {
+                // Remove selected class from all buttons
+                document.querySelectorAll('.metadata-select-button').forEach(btn => {
+                    btn.classList.remove('selected');
+                    btn.style.borderColor = '#ddd';
+                    btn.style.background = 'white';
+                });
+                // Add selected class to Labels button
+                labelsButton.classList.add('selected');
+                labelsButton.style.borderColor = '#3366cc';
+                labelsButton.style.background = '#e6f0ff';
+            }
+        }, 150);
+    }
+
     // Add Label functionality
     const addLabelBtn = document.getElementById('add-label');
     if (addLabelBtn) {
-        addLabelBtn.addEventListener('click', () => {
-            // Get total items from current state for custom mappings
-            const currentState = window.mappingStepState?.getState();
-            const totalItems = currentState?.fetchedData?.length || 0;
-
-            // Create empty key data for the modal
-            const emptyKeyData = {
-                key: '',
-                type: 'unknown',
-                frequency: totalItems,
-                totalItems: totalItems,
-                sampleValue: ''
-            };
-
-            // Open the mapping modal with empty data
-            openMappingModal(emptyKeyData);
-
-            // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
-            // then set the label property
-            setTimeout(() => {
-                const labelProperty = {
-                    id: 'label',
-                    label: 'Labels',
-                    description: 'Main name for entities',
-                    datatype: 'monolingualtext',
-                    datatypeLabel: 'Monolingual text',
-                    isMetadata: true,
-                    helpUrl: 'https://www.wikidata.org/wiki/Help:Label'
-                };
-
-                // Set the selected property
-                window.currentMappingSelectedProperty = labelProperty;
-
-                // Update UI to show selection
-                const selectedSection = document.getElementById('selected-property');
-                const selectedDetails = document.getElementById('selected-property-details');
-
-                if (selectedSection && selectedDetails) {
-                    selectedSection.style.display = 'block';
-                    selectedDetails.innerHTML = `
-                        <div class="property-info metadata-property-info">
-                            <h3>🏷️ ${labelProperty.label}</h3>
-                            <p class="property-id">Metadata Field</p>
-                            <p>${labelProperty.description}</p>
-                            <a href="${labelProperty.helpUrl}" target="_blank" rel="noopener">
-                                Learn more about ${labelProperty.label} →
-                            </a>
-                            <div class="metadata-notice" style="margin-top: 10px; padding: 10px; background: #fff3cd; border-radius: 5px;">
-                                <strong>Note:</strong> This is a metadata field for Wikidata entities.
-                                Values will be treated as language-specific text.
-                            </div>
-                        </div>
-                    `;
-                }
-
-                // Update datatype display
-                const datatypeDisplay = document.getElementById('detected-datatype');
-                if (datatypeDisplay) {
-                    datatypeDisplay.innerHTML = `
-                        <span class="datatype-label">Monolingual text</span>
-                    `;
-                }
-
-                // Show datatype section
-                const datatypeSection = document.getElementById('datatype-info-section');
-                if (datatypeSection) {
-                    datatypeSection.style.display = 'block';
-                }
-
-                // Highlight the Labels button if it exists
-                const labelsButton = Array.from(document.querySelectorAll('.metadata-select-button'))
-                    .find(btn => btn.textContent.includes('Labels'));
-                if (labelsButton) {
-                    // Remove selected class from all buttons
-                    document.querySelectorAll('.metadata-select-button').forEach(btn => {
-                        btn.classList.remove('selected');
-                        btn.style.borderColor = '#ddd';
-                        btn.style.background = 'white';
-                    });
-                    // Add selected class to Labels button
-                    labelsButton.classList.add('selected');
-                    labelsButton.style.borderColor = '#3366cc';
-                    labelsButton.style.background = '#e6f0ff';
-                }
-            }, 150);
-        });
+        addLabelBtn.addEventListener('click', openModalWithLabelPreselected);
     }
 
     // Add Description functionality
@@ -485,78 +491,86 @@ export function setupMappingStep(state) {
         });
     }
 
+    /**
+     * Opens the mapping modal with Instance of pre-selected
+     * Used by both "Add Instance of" button and required property placeholder
+     */
+    function openModalWithInstanceOfPreselected() {
+        // Get total items from current state for custom mappings
+        const currentState = window.mappingStepState?.getState();
+        const totalItems = currentState?.fetchedData?.length || 0;
+
+        // Create empty key data for the modal
+        const emptyKeyData = {
+            key: '',
+            type: 'unknown',
+            frequency: totalItems,
+            totalItems: totalItems,
+            sampleValue: ''
+        };
+
+        // Open the mapping modal with empty data
+        openMappingModal(emptyKeyData);
+
+        // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
+        // then set the instance of property
+        setTimeout(() => {
+            const instanceOfProperty = {
+                id: 'P31',
+                label: 'instance of',
+                description: 'that class of which this subject is a particular example',
+                datatype: 'wikibase-item',
+                datatypeLabel: 'Item',
+                url: 'https://www.wikidata.org/wiki/Property:P31'
+            };
+
+            // Set the selected property
+            window.currentMappingSelectedProperty = instanceOfProperty;
+
+            // Update UI to show selection
+            const selectedSection = document.getElementById('selected-property');
+            const selectedDetails = document.getElementById('selected-property-details');
+
+            if (selectedSection && selectedDetails) {
+                selectedSection.style.display = 'block';
+                selectedDetails.innerHTML = `
+                    <div class="property-info">
+                        <h3>${instanceOfProperty.label}</h3>
+                        <p class="property-id">${instanceOfProperty.id}</p>
+                        <p>${instanceOfProperty.description}</p>
+                        <a href="${instanceOfProperty.url}" target="_blank" rel="noopener">
+                            View on Wikidata →
+                        </a>
+                    </div>
+                `;
+            }
+
+            // Update datatype display
+            const datatypeDisplay = document.getElementById('detected-datatype');
+            if (datatypeDisplay) {
+                datatypeDisplay.innerHTML = `
+                    <span class="datatype-label">Item</span>
+                `;
+            }
+
+            // Show datatype section
+            const datatypeSection = document.getElementById('datatype-info-section');
+            if (datatypeSection) {
+                datatypeSection.style.display = 'block';
+            }
+
+            // Note: No metadata button to highlight since P31 is a regular property
+        }, 150);
+    }
+
     // Add Instance of functionality
     const addInstanceOfBtn = document.getElementById('add-instance-of');
     if (addInstanceOfBtn) {
-        addInstanceOfBtn.addEventListener('click', () => {
-            // Get total items from current state for custom mappings
-            const currentState = window.mappingStepState?.getState();
-            const totalItems = currentState?.fetchedData?.length || 0;
-
-            // Create empty key data for the modal
-            const emptyKeyData = {
-                key: '',
-                type: 'unknown',
-                frequency: totalItems,
-                totalItems: totalItems,
-                sampleValue: ''
-            };
-
-            // Open the mapping modal with empty data
-            openMappingModal(emptyKeyData);
-
-            // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
-            // then set the instance of property
-            setTimeout(() => {
-                const instanceOfProperty = {
-                    id: 'P31',
-                    label: 'instance of',
-                    description: 'that class of which this subject is a particular example',
-                    datatype: 'wikibase-item',
-                    datatypeLabel: 'Item',
-                    url: 'https://www.wikidata.org/wiki/Property:P31'
-                };
-
-                // Set the selected property
-                window.currentMappingSelectedProperty = instanceOfProperty;
-
-                // Update UI to show selection
-                const selectedSection = document.getElementById('selected-property');
-                const selectedDetails = document.getElementById('selected-property-details');
-
-                if (selectedSection && selectedDetails) {
-                    selectedSection.style.display = 'block';
-                    selectedDetails.innerHTML = `
-                        <div class="property-info">
-                            <h3>${instanceOfProperty.label}</h3>
-                            <p class="property-id">${instanceOfProperty.id}</p>
-                            <p>${instanceOfProperty.description}</p>
-                            <a href="${instanceOfProperty.url}" target="_blank" rel="noopener">
-                                View on Wikidata →
-                            </a>
-                        </div>
-                    `;
-                }
-
-                // Update datatype display
-                const datatypeDisplay = document.getElementById('detected-datatype');
-                if (datatypeDisplay) {
-                    datatypeDisplay.innerHTML = `
-                        <span class="datatype-label">Item</span>
-                    `;
-                }
-
-                // Show datatype section
-                const datatypeSection = document.getElementById('datatype-info-section');
-                if (datatypeSection) {
-                    datatypeSection.style.display = 'block';
-                }
-
-                // Note: No metadata button to highlight since P31 is a regular property
-            }, 150);
-        });
+        addInstanceOfBtn.addEventListener('click', openModalWithInstanceOfPreselected);
     }
 
     // Export functions globally for use by other modules
     window.openMappingModal = openMappingModal;
+    window.openModalWithLabelPreselected = openModalWithLabelPreselected;
+    window.openModalWithInstanceOfPreselected = openModalWithInstanceOfPreselected;
 }

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -299,6 +299,248 @@ export function setupMappingStep(state) {
         });
     }
 
+    // Add Description functionality
+    const addDescriptionBtn = document.getElementById('add-description');
+    if (addDescriptionBtn) {
+        addDescriptionBtn.addEventListener('click', () => {
+            // Create empty key data for the modal
+            const emptyKeyData = {
+                key: '',
+                type: 'unknown',
+                frequency: 0,
+                totalItems: 0,
+                sampleValue: ''
+            };
+
+            // Open the mapping modal with empty data
+            openMappingModal(emptyKeyData);
+
+            // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
+            // then set the description property
+            setTimeout(() => {
+                const descriptionProperty = {
+                    id: 'description',
+                    label: 'Descriptions',
+                    description: 'Short disambiguating phrases',
+                    datatype: 'monolingualtext',
+                    datatypeLabel: 'Monolingual text',
+                    isMetadata: true,
+                    helpUrl: 'https://www.wikidata.org/wiki/Help:Description'
+                };
+
+                // Set the selected property
+                window.currentMappingSelectedProperty = descriptionProperty;
+
+                // Update UI to show selection
+                const selectedSection = document.getElementById('selected-property');
+                const selectedDetails = document.getElementById('selected-property-details');
+
+                if (selectedSection && selectedDetails) {
+                    selectedSection.style.display = 'block';
+                    selectedDetails.innerHTML = `
+                        <div class="property-info metadata-property-info">
+                            <h3>📝 ${descriptionProperty.label}</h3>
+                            <p class="property-id">Metadata Field</p>
+                            <p>${descriptionProperty.description}</p>
+                            <a href="${descriptionProperty.helpUrl}" target="_blank" rel="noopener">
+                                Learn more about ${descriptionProperty.label} →
+                            </a>
+                            <div class="metadata-notice" style="margin-top: 10px; padding: 10px; background: #fff3cd; border-radius: 5px;">
+                                <strong>Note:</strong> This is a metadata field for Wikidata entities.
+                                Values will be treated as language-specific text.
+                            </div>
+                        </div>
+                    `;
+                }
+
+                // Update datatype display
+                const datatypeDisplay = document.getElementById('detected-datatype');
+                if (datatypeDisplay) {
+                    datatypeDisplay.innerHTML = `
+                        <span class="datatype-label">Monolingual text</span>
+                    `;
+                }
+
+                // Show datatype section
+                const datatypeSection = document.getElementById('datatype-info-section');
+                if (datatypeSection) {
+                    datatypeSection.style.display = 'block';
+                }
+
+                // Highlight the Descriptions button if it exists
+                const descriptionsButton = Array.from(document.querySelectorAll('.metadata-select-button'))
+                    .find(btn => btn.textContent.includes('Descriptions'));
+                if (descriptionsButton) {
+                    // Remove selected class from all buttons
+                    document.querySelectorAll('.metadata-select-button').forEach(btn => {
+                        btn.classList.remove('selected');
+                        btn.style.borderColor = '#ddd';
+                        btn.style.background = 'white';
+                    });
+                    // Add selected class to Descriptions button
+                    descriptionsButton.classList.add('selected');
+                    descriptionsButton.style.borderColor = '#3366cc';
+                    descriptionsButton.style.background = '#e6f0ff';
+                }
+            }, 150);
+        });
+    }
+
+    // Add Aliases functionality
+    const addAliasesBtn = document.getElementById('add-aliases');
+    if (addAliasesBtn) {
+        addAliasesBtn.addEventListener('click', () => {
+            // Create empty key data for the modal
+            const emptyKeyData = {
+                key: '',
+                type: 'unknown',
+                frequency: 0,
+                totalItems: 0,
+                sampleValue: ''
+            };
+
+            // Open the mapping modal with empty data
+            openMappingModal(emptyKeyData);
+
+            // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
+            // then set the aliases property
+            setTimeout(() => {
+                const aliasesProperty = {
+                    id: 'aliases',
+                    label: 'Aliases',
+                    description: 'Alternative names',
+                    datatype: 'monolingualtext',
+                    datatypeLabel: 'Monolingual text',
+                    isMetadata: true,
+                    helpUrl: 'https://www.wikidata.org/wiki/Help:Aliases'
+                };
+
+                // Set the selected property
+                window.currentMappingSelectedProperty = aliasesProperty;
+
+                // Update UI to show selection
+                const selectedSection = document.getElementById('selected-property');
+                const selectedDetails = document.getElementById('selected-property-details');
+
+                if (selectedSection && selectedDetails) {
+                    selectedSection.style.display = 'block';
+                    selectedDetails.innerHTML = `
+                        <div class="property-info metadata-property-info">
+                            <h3>🔄 ${aliasesProperty.label}</h3>
+                            <p class="property-id">Metadata Field</p>
+                            <p>${aliasesProperty.description}</p>
+                            <a href="${aliasesProperty.helpUrl}" target="_blank" rel="noopener">
+                                Learn more about ${aliasesProperty.label} →
+                            </a>
+                            <div class="metadata-notice" style="margin-top: 10px; padding: 10px; background: #fff3cd; border-radius: 5px;">
+                                <strong>Note:</strong> This is a metadata field for Wikidata entities.
+                                Values will be treated as language-specific text.
+                            </div>
+                        </div>
+                    `;
+                }
+
+                // Update datatype display
+                const datatypeDisplay = document.getElementById('detected-datatype');
+                if (datatypeDisplay) {
+                    datatypeDisplay.innerHTML = `
+                        <span class="datatype-label">Monolingual text</span>
+                    `;
+                }
+
+                // Show datatype section
+                const datatypeSection = document.getElementById('datatype-info-section');
+                if (datatypeSection) {
+                    datatypeSection.style.display = 'block';
+                }
+
+                // Highlight the Aliases button if it exists
+                const aliasesButton = Array.from(document.querySelectorAll('.metadata-select-button'))
+                    .find(btn => btn.textContent.includes('Aliases'));
+                if (aliasesButton) {
+                    // Remove selected class from all buttons
+                    document.querySelectorAll('.metadata-select-button').forEach(btn => {
+                        btn.classList.remove('selected');
+                        btn.style.borderColor = '#ddd';
+                        btn.style.background = 'white';
+                    });
+                    // Add selected class to Aliases button
+                    aliasesButton.classList.add('selected');
+                    aliasesButton.style.borderColor = '#3366cc';
+                    aliasesButton.style.background = '#e6f0ff';
+                }
+            }, 150);
+        });
+    }
+
+    // Add Instance of functionality
+    const addInstanceOfBtn = document.getElementById('add-instance-of');
+    if (addInstanceOfBtn) {
+        addInstanceOfBtn.addEventListener('click', () => {
+            // Create empty key data for the modal
+            const emptyKeyData = {
+                key: '',
+                type: 'unknown',
+                frequency: 0,
+                totalItems: 0,
+                sampleValue: ''
+            };
+
+            // Open the mapping modal with empty data
+            openMappingModal(emptyKeyData);
+
+            // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
+            // then set the instance of property
+            setTimeout(() => {
+                const instanceOfProperty = {
+                    id: 'P31',
+                    label: 'instance of',
+                    description: 'that class of which this subject is a particular example',
+                    datatype: 'wikibase-item',
+                    datatypeLabel: 'Item',
+                    url: 'https://www.wikidata.org/wiki/Property:P31'
+                };
+
+                // Set the selected property
+                window.currentMappingSelectedProperty = instanceOfProperty;
+
+                // Update UI to show selection
+                const selectedSection = document.getElementById('selected-property');
+                const selectedDetails = document.getElementById('selected-property-details');
+
+                if (selectedSection && selectedDetails) {
+                    selectedSection.style.display = 'block';
+                    selectedDetails.innerHTML = `
+                        <div class="property-info">
+                            <h3>${instanceOfProperty.label}</h3>
+                            <p class="property-id">${instanceOfProperty.id}</p>
+                            <p>${instanceOfProperty.description}</p>
+                            <a href="${instanceOfProperty.url}" target="_blank" rel="noopener">
+                                View on Wikidata →
+                            </a>
+                        </div>
+                    `;
+                }
+
+                // Update datatype display
+                const datatypeDisplay = document.getElementById('detected-datatype');
+                if (datatypeDisplay) {
+                    datatypeDisplay.innerHTML = `
+                        <span class="datatype-label">Item</span>
+                    `;
+                }
+
+                // Show datatype section
+                const datatypeSection = document.getElementById('datatype-info-section');
+                if (datatypeSection) {
+                    datatypeSection.style.display = 'block';
+                }
+
+                // Note: No metadata button to highlight since P31 is a regular property
+            }, 150);
+        });
+    }
+
     // Export functions globally for use by other modules
     window.openMappingModal = openMappingModal;
 }

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -216,12 +216,16 @@ export function setupMappingStep(state) {
     const addLabelBtn = document.getElementById('add-label');
     if (addLabelBtn) {
         addLabelBtn.addEventListener('click', () => {
+            // Get total items from current state for custom mappings
+            const currentState = window.mappingStepState?.getState();
+            const totalItems = currentState?.fetchedData?.length || 0;
+
             // Create empty key data for the modal
             const emptyKeyData = {
                 key: '',
                 type: 'unknown',
-                frequency: 0,
-                totalItems: 0,
+                frequency: totalItems,
+                totalItems: totalItems,
                 sampleValue: ''
             };
 
@@ -303,12 +307,16 @@ export function setupMappingStep(state) {
     const addDescriptionBtn = document.getElementById('add-description');
     if (addDescriptionBtn) {
         addDescriptionBtn.addEventListener('click', () => {
+            // Get total items from current state for custom mappings
+            const currentState = window.mappingStepState?.getState();
+            const totalItems = currentState?.fetchedData?.length || 0;
+
             // Create empty key data for the modal
             const emptyKeyData = {
                 key: '',
                 type: 'unknown',
-                frequency: 0,
-                totalItems: 0,
+                frequency: totalItems,
+                totalItems: totalItems,
                 sampleValue: ''
             };
 
@@ -390,12 +398,16 @@ export function setupMappingStep(state) {
     const addAliasesBtn = document.getElementById('add-aliases');
     if (addAliasesBtn) {
         addAliasesBtn.addEventListener('click', () => {
+            // Get total items from current state for custom mappings
+            const currentState = window.mappingStepState?.getState();
+            const totalItems = currentState?.fetchedData?.length || 0;
+
             // Create empty key data for the modal
             const emptyKeyData = {
                 key: '',
                 type: 'unknown',
-                frequency: 0,
-                totalItems: 0,
+                frequency: totalItems,
+                totalItems: totalItems,
                 sampleValue: ''
             };
 
@@ -477,12 +489,16 @@ export function setupMappingStep(state) {
     const addInstanceOfBtn = document.getElementById('add-instance-of');
     if (addInstanceOfBtn) {
         addInstanceOfBtn.addEventListener('click', () => {
+            // Get total items from current state for custom mappings
+            const currentState = window.mappingStepState?.getState();
+            const totalItems = currentState?.fetchedData?.length || 0;
+
             // Create empty key data for the modal
             const emptyKeyData = {
                 key: '',
                 type: 'unknown',
-                frequency: 0,
-                totalItems: 0,
+                frequency: totalItems,
+                totalItems: totalItems,
                 sampleValue: ''
             };
 

--- a/src/js/steps/mapping.js
+++ b/src/js/steps/mapping.js
@@ -206,12 +206,99 @@ export function setupMappingStep(state) {
                 totalItems: 0,
                 sampleValue: ''
             };
-            
+
             // Open the mapping modal with empty data
             openMappingModal(emptyKeyData);
         });
     }
-    
+
+    // Add Label functionality
+    const addLabelBtn = document.getElementById('add-label');
+    if (addLabelBtn) {
+        addLabelBtn.addEventListener('click', () => {
+            // Create empty key data for the modal
+            const emptyKeyData = {
+                key: '',
+                type: 'unknown',
+                frequency: 0,
+                totalItems: 0,
+                sampleValue: ''
+            };
+
+            // Open the mapping modal with empty data
+            openMappingModal(emptyKeyData);
+
+            // Wait 150ms for setupPropertySearch to finish (it runs at 100ms),
+            // then set the label property
+            setTimeout(() => {
+                const labelProperty = {
+                    id: 'label',
+                    label: 'Labels',
+                    description: 'Main name for entities',
+                    datatype: 'monolingualtext',
+                    datatypeLabel: 'Monolingual text',
+                    isMetadata: true,
+                    helpUrl: 'https://www.wikidata.org/wiki/Help:Label'
+                };
+
+                // Set the selected property
+                window.currentMappingSelectedProperty = labelProperty;
+
+                // Update UI to show selection
+                const selectedSection = document.getElementById('selected-property');
+                const selectedDetails = document.getElementById('selected-property-details');
+
+                if (selectedSection && selectedDetails) {
+                    selectedSection.style.display = 'block';
+                    selectedDetails.innerHTML = `
+                        <div class="property-info metadata-property-info">
+                            <h3>🏷️ ${labelProperty.label}</h3>
+                            <p class="property-id">Metadata Field</p>
+                            <p>${labelProperty.description}</p>
+                            <a href="${labelProperty.helpUrl}" target="_blank" rel="noopener">
+                                Learn more about ${labelProperty.label} →
+                            </a>
+                            <div class="metadata-notice" style="margin-top: 10px; padding: 10px; background: #fff3cd; border-radius: 5px;">
+                                <strong>Note:</strong> This is a metadata field for Wikidata entities.
+                                Values will be treated as language-specific text.
+                            </div>
+                        </div>
+                    `;
+                }
+
+                // Update datatype display
+                const datatypeDisplay = document.getElementById('detected-datatype');
+                if (datatypeDisplay) {
+                    datatypeDisplay.innerHTML = `
+                        <span class="datatype-label">Monolingual text</span>
+                    `;
+                }
+
+                // Show datatype section
+                const datatypeSection = document.getElementById('datatype-info-section');
+                if (datatypeSection) {
+                    datatypeSection.style.display = 'block';
+                }
+
+                // Highlight the Labels button if it exists
+                const labelsButton = Array.from(document.querySelectorAll('.metadata-select-button'))
+                    .find(btn => btn.textContent.includes('Labels'));
+                if (labelsButton) {
+                    // Remove selected class from all buttons
+                    document.querySelectorAll('.metadata-select-button').forEach(btn => {
+                        btn.classList.remove('selected');
+                        btn.style.borderColor = '#ddd';
+                        btn.style.background = 'white';
+                    });
+                    // Add selected class to Labels button
+                    labelsButton.classList.add('selected');
+                    labelsButton.style.borderColor = '#3366cc';
+                    labelsButton.style.background = '#e6f0ff';
+                }
+            }, 150);
+        });
+    }
+
     // Export functions globally for use by other modules
     window.openMappingModal = openMappingModal;
 }


### PR DESCRIPTION
## Summary
- Add quick-access buttons for common metadata fields (Label, Description, Aliases, Instance of, Other Property)
- Add visual indicators for required properties (Label and Instance of) in Mapped Keys section
- Reposition and restyle "Add Wikidata Property" button as "Add Other Wikidata Property"
- Fix monolingual text language selection dropdown click handling
- Remove deprecated issues section from designer step
- Fix custom mappings frequency indicator to show all items

## Test plan
- [ ] Verify "Add Label" button opens modal with Label pre-selected
- [ ] Verify "Add Description" button opens modal with Description pre-selected  
- [ ] Verify "Add Aliases" button opens modal with Aliases pre-selected
- [ ] Verify "Add Instance of" button opens modal with Instance of (P31) pre-selected
- [ ] Verify "Add Other Wikidata Property" button opens empty modal
- [ ] Verify button order: Label, Description, Aliases, Instance of, Other Property
- [ ] Verify "Add Other Wikidata Property" button is grey (secondary style)
- [ ] Verify required property placeholders appear in Mapped Keys when Label/Instance of not mapped
- [ ] Verify placeholders are clickable and open appropriate modals
- [ ] Verify placeholders disappear when properties are mapped
- [ ] Verify language selection works in monolingual text modal
- [ ] Verify custom mappings show correct frequency indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)