### PR TITLE
Add custom reference functionality and editing to Step 4

### DIFF
--- a/JS_MODULE_MAP.md
+++ b/JS_MODULE_MAP.md
@@ -11,6 +11,7 @@
 | Search Wikidata properties | `mapping/core/property-searcher.js` |
 | Transform field values | `transformations.js` |
 | Reconcile entities with Wikidata | `steps/reconciliation.js`, `reconciliation/` |
+| Detect and display reference links | `steps/step4.js`, `references/` |
 | Call Wikidata API | `api/wikidata.js` |
 | Create UI elements | `ui/components.js` |
 | Handle modals | `modals.js` |
@@ -72,10 +73,10 @@ The application follows a **modular, event-driven architecture**:
 - Key features: Batch processing, entity matching, progress tracking
 - Dependencies: reconciliation/*, api/wikidata.js
 
-### **designer.js**
-- Purpose: Step 4 - References (placeholder step - emptied)
-- Key features: Minimal placeholder setup, navigation handling
-- Dependencies: None (placeholder step)
+### **step4.js**
+- Purpose: Step 4 - Detect and display reference links
+- Key features: Automatic reference detection, display with counts and examples
+- Dependencies: references/core/detector.js, references/ui/display.js, events.js
 
 ### **export.js**
 - Purpose: Step 5 - Generate QuickStatements for Wikidata import
@@ -194,6 +195,23 @@ The application follows a **modular, event-driven architecture**:
 - Key exports: `createExternalIdModal()`, `initializeExternalIdModal()`
 - Features: Real-time regex validation, user override capability, property constraint display
 
+### References Module (`references/`)
+
+#### Core (`references/core/`)
+
+**detector.js**
+- Purpose: Detect reference links from Omeka S API data
+- Key exports: `detectReferences()`, `detectOmekaItemLink()`, `detectOCLCLinks()`, `detectARKIdentifiers()`
+- Reference types: Omeka Item API links, OCLC WorldCat links, ARK identifiers
+- Returns: Item-specific references with summary statistics
+
+#### UI (`references/ui/`)
+
+**display.js**
+- Purpose: Render reference detection results with counts and tooltips
+- Key exports: `renderReferencesSection()`, `createReferenceTypeCard()`, `createTooltip()`
+- Features: Reference type cards, item counts, example value tooltips
+
 ### Index Files
 - `mapping/index.js` - Re-exports all mapping module functions
 - `reconciliation/index.js` - Re-exports all reconciliation functions
@@ -299,7 +317,7 @@ app.js
     ├── input.js ←── utils/cors-proxy.js
     ├── mapping.js ←── mapping/* + transformations.js
     ├── reconciliation.js ←── reconciliation/*
-    ├── designer.js
+    ├── step4.js ←── references/*
     └── export.js
 
 api/wikidata.js ← used by mapping & reconciliation

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3768,12 +3768,9 @@ pre.sample-value {
     align-self: stretch;
 }
 
-/* Step 4: References (placeholder step - emptied) */
+/* Step 4: References */
 .references-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 2rem;
-    text-align: center;
+    /* No specific styling - uses full width like mapping-container */
 }
 
 /* Modal Container Styles */

--- a/src/index.html
+++ b/src/index.html
@@ -194,8 +194,6 @@
             <section id="step4" class="step-content">
                 <h2>Step 4: References</h2>
                 <div class="references-container">
-                    <p class="info">This step automatically detects reference links in your API data that can be added to Wikidata statements.</p>
-
                     <div id="references-list" class="references-list">
                         <!-- References will be populated here by JavaScript -->
                     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -194,7 +194,11 @@
             <section id="step4" class="step-content">
                 <h2>Step 4: References</h2>
                 <div class="references-container">
-                    <p>References configuration will be added here.</p>
+                    <p class="info">This step automatically detects reference links in your API data that can be added to Wikidata statements.</p>
+
+                    <div id="references-list" class="references-list">
+                        <!-- References will be populated here by JavaScript -->
+                    </div>
 
                     <div class="navigation-buttons">
                         <button id="back-to-reconciliation" class="button button--secondary">Back to Reconciliation</button>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,7 +12,7 @@ import { setupState } from './state.js';
 import { setupInputStep } from './steps/input.js';
 import { setupMappingStep } from './steps/mapping.js';
 import { setupReconciliationStep } from './steps/reconciliation.js';
-import { setupDesignerStep } from './steps/designer.js';
+import { setupStep4 } from './steps/step4.js';
 import { setupExportStep } from './steps/export.js';
 import { setupModals } from './modals.js';
 
@@ -33,7 +33,7 @@ function initializeApp() {
     setupInputStep(state);
     setupMappingStep(state);
     setupReconciliationStep(state);
-    setupDesignerStep(state);
+    setupStep4(state);
     setupExportStep(state);
     
     // Set up application-level event listeners

--- a/src/js/references/core/custom-references.js
+++ b/src/js/references/core/custom-references.js
@@ -138,3 +138,58 @@ export function mergeCustomReferencesIntoSummary(summary, customReferences) {
 
     return merged;
 }
+
+/**
+ * Gets a display-friendly base URL without protocol
+ * @param {string} baseUrl - Full base URL with protocol
+ * @returns {string} Base URL without https:// or http://
+ */
+export function getDisplayBaseUrl(baseUrl) {
+    if (!baseUrl) return '';
+
+    return baseUrl
+        .replace(/^https?:\/\//, '') // Remove protocol
+        .replace(/\/$/, ''); // Remove trailing slash
+}
+
+/**
+ * Converts auto-detected references to editable format
+ * @param {string} type - Reference type (e.g., 'omeka-item', 'oclc', 'ark')
+ * @param {Object} state - Application state management instance
+ * @returns {Object} Reference data in editable format {name, type, items: [{itemId, url}]}
+ */
+export function convertAutoDetectedToEditable(type, state) {
+    const currentState = state.getState();
+    const itemReferences = currentState.references?.itemReferences || {};
+
+    const items = [];
+
+    // Extract all references of this type from itemReferences
+    Object.entries(itemReferences).forEach(([itemId, refs]) => {
+        const matchingRef = refs.find(ref => ref.type === type);
+        if (matchingRef) {
+            items.push({
+                itemId,
+                url: matchingRef.url
+            });
+        }
+    });
+
+    // Get label for this type
+    const typeLabels = {
+        'omeka-item': 'Omeka item',
+        'oclc': 'OCLC WorldCat',
+        'ark': 'ARK identifier'
+    };
+
+    const name = typeLabels[type] || type;
+    const baseUrl = items.length > 0 ? extractBaseUrl(items[0].url) : '';
+
+    return {
+        type,
+        name,
+        items,
+        baseUrl,
+        isAutoDetected: true
+    };
+}

--- a/src/js/references/core/custom-references.js
+++ b/src/js/references/core/custom-references.js
@@ -1,0 +1,140 @@
+/**
+ * Custom Reference Management Module
+ * Handles creation, validation, and processing of user-defined custom references
+ * @module references/core/custom-references
+ */
+
+/**
+ * Creates a custom reference object from user input
+ * @param {string} name - Name of the custom reference
+ * @param {Array} itemReferences - Array of {itemId, url} objects
+ * @returns {Object} Custom reference object
+ */
+export function createCustomReference(name, itemReferences) {
+    // Filter out items with empty URLs
+    const validItems = itemReferences.filter(item => item.url && item.url.trim() !== '');
+
+    if (validItems.length === 0) {
+        throw new Error('At least one item must have a reference URL');
+    }
+
+    // Extract base URL from the first valid reference
+    const baseUrl = extractBaseUrl(validItems[0].url);
+
+    return {
+        id: `custom-ref-${Date.now()}`,
+        name: name || 'Custom reference',
+        type: 'custom',
+        items: validItems,
+        baseUrl,
+        count: validItems.length,
+        createdAt: new Date().toISOString()
+    };
+}
+
+/**
+ * Extracts the base URL (origin) from a full URL
+ * @param {string} url - Full URL
+ * @returns {string} Base URL (protocol + domain)
+ */
+export function extractBaseUrl(url) {
+    try {
+        const urlObj = new URL(url);
+        return urlObj.origin;
+    } catch (error) {
+        // If URL parsing fails, try to extract domain manually
+        const match = url.match(/^(https?:\/\/[^\/]+)/);
+        return match ? match[1] : url;
+    }
+}
+
+/**
+ * Validates a custom reference
+ * @param {string} name - Reference name
+ * @param {Array} itemReferences - Array of {itemId, url} objects
+ * @returns {Object} Validation result {isValid, errors}
+ */
+export function validateCustomReference(name, itemReferences) {
+    const errors = [];
+
+    if (!name || name.trim() === '') {
+        errors.push('Reference name cannot be empty');
+    }
+
+    if (!Array.isArray(itemReferences)) {
+        errors.push('Invalid item references format');
+        return { isValid: false, errors };
+    }
+
+    const validItems = itemReferences.filter(item => item.url && item.url.trim() !== '');
+
+    if (validItems.length === 0) {
+        errors.push('At least one item must have a reference URL');
+    }
+
+    // Validate each URL
+    validItems.forEach((item, index) => {
+        try {
+            new URL(item.url);
+        } catch (e) {
+            // Try to validate as a partial URL
+            if (!item.url.match(/^https?:\/\/.+/)) {
+                errors.push(`Invalid URL format for item ${index + 1}: ${item.url}`);
+            }
+        }
+    });
+
+    return {
+        isValid: errors.length === 0,
+        errors
+    };
+}
+
+/**
+ * Converts custom reference to summary format for display
+ * @param {Object} customRef - Custom reference object
+ * @returns {Object} Summary format {count, examples}
+ */
+export function customReferenceToSummary(customRef) {
+    return {
+        count: customRef.count,
+        examples: customRef.items.slice(0, 10).map(item => ({
+            itemId: item.itemId,
+            value: item.url
+        }))
+    };
+}
+
+/**
+ * Gets the label for a custom reference type
+ * @param {Object} customRef - Custom reference object
+ * @returns {string} Display label
+ */
+export function getCustomReferenceLabel(customRef) {
+    return customRef.name;
+}
+
+/**
+ * Gets the description for a custom reference type
+ * @param {Object} customRef - Custom reference object
+ * @returns {string} Description
+ */
+export function getCustomReferenceDescription(customRef) {
+    return customRef.baseUrl;
+}
+
+/**
+ * Merges custom references into the references summary
+ * @param {Object} summary - Existing summary from auto-detection
+ * @param {Array} customReferences - Array of custom reference objects
+ * @returns {Object} Merged summary
+ */
+export function mergeCustomReferencesIntoSummary(summary, customReferences) {
+    const merged = { ...summary };
+
+    customReferences.forEach(customRef => {
+        merged[customRef.id] = customReferenceToSummary(customRef);
+    });
+
+    return merged;
+}

--- a/src/js/references/core/custom-references.js
+++ b/src/js/references/core/custom-references.js
@@ -4,6 +4,8 @@
  * @module references/core/custom-references
  */
 
+import { getReferenceTypeLabel } from './detector.js';
+
 /**
  * Creates a custom reference object from user input
  * @param {string} name - Name of the custom reference
@@ -188,14 +190,8 @@ export function convertAutoDetectedToEditable(type, state) {
         }
     });
 
-    // Get label for this type
-    const typeLabels = {
-        'omeka-item': 'Omeka item',
-        'oclc': 'OCLC WorldCat',
-        'ark': 'ARK identifier'
-    };
-
-    const name = typeLabels[type] || type;
+    // Get label for this type using the centralized function
+    const name = getReferenceTypeLabel(type);
     const baseUrl = items.length > 0 ? extractBaseUrl(items[0].url) : '';
 
     return {

--- a/src/js/references/core/custom-references.js
+++ b/src/js/references/core/custom-references.js
@@ -8,9 +8,10 @@
  * Creates a custom reference object from user input
  * @param {string} name - Name of the custom reference
  * @param {Array} itemReferences - Array of {itemId, url} objects
+ * @param {Object} options - Optional parameters {id, originalType}
  * @returns {Object} Custom reference object
  */
-export function createCustomReference(name, itemReferences) {
+export function createCustomReference(name, itemReferences, options = {}) {
     // Filter out items with empty URLs
     const validItems = itemReferences.filter(item => item.url && item.url.trim() !== '');
 
@@ -21,15 +22,27 @@ export function createCustomReference(name, itemReferences) {
     // Extract base URL from the first valid reference
     const baseUrl = extractBaseUrl(validItems[0].url);
 
-    return {
-        id: `custom-ref-${Date.now()}`,
+    const reference = {
+        id: options.id || `custom-ref-${Date.now()}`,
         name: name || 'Custom reference',
         type: 'custom',
         items: validItems,
         baseUrl,
         count: validItems.length,
-        createdAt: new Date().toISOString()
+        createdAt: options.createdAt || new Date().toISOString()
     };
+
+    // If this is a conversion from auto-detected, store the original type
+    if (options.originalType) {
+        reference.originalType = options.originalType;
+    }
+
+    // If this is an update, add updatedAt timestamp
+    if (options.id && options.createdAt) {
+        reference.updatedAt = new Date().toISOString();
+    }
+
+    return reference;
 }
 
 /**

--- a/src/js/references/core/detector.js
+++ b/src/js/references/core/detector.js
@@ -204,9 +204,9 @@ export function detectARKIdentifiers(item) {
  */
 export function getReferenceTypeLabel(type) {
     const labels = {
-        'omeka-item': 'Omeka Item Links',
-        'oclc': 'OCLC WorldCat Links',
-        'ark': 'ARK Identifiers'
+        'omeka-item': 'Omeka item',
+        'oclc': 'OCLC WorldCat',
+        'ark': 'ARK identifier'
     };
     return labels[type] || type;
 }
@@ -218,9 +218,9 @@ export function getReferenceTypeLabel(type) {
  */
 export function getReferenceTypeDescription(type) {
     const descriptions = {
-        'omeka-item': 'Direct links to Omeka S item API endpoints',
-        'oclc': 'OCLC WorldCat bibliographic control numbers',
-        'ark': 'Archival Resource Key persistent identifiers'
+        'omeka-item': 'Link to the item through Omeka S',
+        'oclc': 'OCLC WorldCat bibliographic identifier',
+        'ark': 'Archival Resource Key persistent identifier'
     };
     return descriptions[type] || '';
 }

--- a/src/js/references/core/detector.js
+++ b/src/js/references/core/detector.js
@@ -204,7 +204,7 @@ export function detectARKIdentifiers(item) {
  */
 export function getReferenceTypeLabel(type) {
     const labels = {
-        'omeka-item': 'Omeka item',
+        'omeka-item': 'Omeka API item',
         'oclc': 'OCLC WorldCat',
         'ark': 'ARK identifier'
     };
@@ -212,15 +212,24 @@ export function getReferenceTypeLabel(type) {
 }
 
 /**
- * Gets a description for a reference type
+ * Gets a description for a reference type by extracting base URL from examples
  * @param {string} type - Reference type
- * @returns {string} Description
+ * @param {Object} data - Reference data with examples array
+ * @returns {string} Base URL without protocol
  */
-export function getReferenceTypeDescription(type) {
-    const descriptions = {
-        'omeka-item': 'Link to the item through Omeka S API',
-        'oclc': 'OCLC WorldCat bibliographic identifier',
-        'ark': 'Archival Resource Key persistent identifier'
-    };
-    return descriptions[type] || '';
+export function getReferenceTypeDescription(type, data) {
+    // Extract base URL from first example
+    if (data && data.examples && data.examples.length > 0) {
+        const firstUrl = data.examples[0].value;
+        try {
+            const url = new URL(firstUrl);
+            // Return origin without protocol
+            return url.hostname;
+        } catch (e) {
+            // If URL parsing fails, try to extract domain manually
+            const match = firstUrl.match(/^https?:\/\/([^\/]+)/);
+            return match ? match[1] : firstUrl;
+        }
+    }
+    return '';
 }

--- a/src/js/references/core/detector.js
+++ b/src/js/references/core/detector.js
@@ -1,0 +1,226 @@
+/**
+ * Reference Detection Module
+ * Detects reference links from Omeka S API data for future Wikidata statement creation
+ *
+ * This module handles three types of references:
+ * 1. Omeka Item API Links - Direct item references
+ * 2. OCLC WorldCat Links - Bibliographic references
+ * 3. ARK Identifiers - Persistent identifiers
+ *
+ * Unlike identifiers in Step 2 (used for reconciliation), these references
+ * are complete URLs that will be added as Wikidata statement values.
+ *
+ * @module references/core/detector
+ */
+
+/**
+ * Detects all references across all items in the dataset
+ * @param {Array} items - Array of Omeka S items
+ * @returns {Object} Detection results with itemReferences and summary
+ * @returns {Object} result.itemReferences - Map of itemId -> array of reference objects
+ * @returns {Object} result.summary - Map of referenceType -> {count, examples}
+ */
+export function detectReferences(items) {
+    if (!Array.isArray(items) || items.length === 0) {
+        return {
+            itemReferences: {},
+            summary: {}
+        };
+    }
+
+    const itemReferences = {};
+    const summary = {
+        'omeka-item': { count: 0, examples: [] },
+        'oclc': { count: 0, examples: [] },
+        'ark': { count: 0, examples: [] }
+    };
+
+    items.forEach((item, index) => {
+        if (!item || typeof item !== 'object') return;
+
+        // Use item's @id as itemId, or fall back to index
+        const itemId = item['@id'] || item.id || `item-${index}`;
+        const references = [];
+
+        // Detect Omeka Item Link
+        const omekaItemLink = detectOmekaItemLink(item);
+        if (omekaItemLink) {
+            references.push({ ...omekaItemLink, itemId });
+            summary['omeka-item'].count++;
+            if (summary['omeka-item'].examples.length < 10) {
+                summary['omeka-item'].examples.push({
+                    itemId,
+                    value: omekaItemLink.url
+                });
+            }
+        }
+
+        // Detect OCLC Links
+        const oclcLinks = detectOCLCLinks(item);
+        if (oclcLinks.length > 0) {
+            oclcLinks.forEach(link => {
+                references.push({ ...link, itemId });
+            });
+            summary['oclc'].count++;
+            if (summary['oclc'].examples.length < 10) {
+                summary['oclc'].examples.push({
+                    itemId,
+                    value: oclcLinks[0].url // Use first OCLC link as example
+                });
+            }
+        }
+
+        // Detect ARK Identifiers
+        const arkIdentifiers = detectARKIdentifiers(item);
+        if (arkIdentifiers.length > 0) {
+            arkIdentifiers.forEach(ark => {
+                references.push({ ...ark, itemId });
+            });
+            summary['ark'].count++;
+            if (summary['ark'].examples.length < 10) {
+                summary['ark'].examples.push({
+                    itemId,
+                    value: arkIdentifiers[0].url // Use first ARK as example
+                });
+            }
+        }
+
+        // Store references for this item
+        if (references.length > 0) {
+            itemReferences[itemId] = references;
+        }
+    });
+
+    return {
+        itemReferences,
+        summary
+    };
+}
+
+/**
+ * Detects Omeka Item API link from top-level @id field
+ * @param {Object} item - Omeka S item object
+ * @returns {Object|null} Reference object or null if not found
+ */
+export function detectOmekaItemLink(item) {
+    if (!item || !item['@id']) return null;
+
+    const id = item['@id'];
+    if (typeof id !== 'string') return null;
+
+    // Check if the @id contains "/items/" pattern
+    if (id.includes('/items/')) {
+        return {
+            type: 'omeka-item',
+            url: id,
+            displayName: 'Omeka Item Link'
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Detects OCLC WorldCat links from schema:sameAs field
+ * @param {Object} item - Omeka S item object
+ * @returns {Array} Array of OCLC reference objects
+ */
+export function detectOCLCLinks(item) {
+    const oclcLinks = [];
+
+    if (!item || !item['schema:sameAs']) return oclcLinks;
+
+    const sameAs = item['schema:sameAs'];
+    if (!Array.isArray(sameAs)) return oclcLinks;
+
+    // Pattern to match OCLC WorldCat URLs
+    const oclcPattern = /worldcat\.org\/oclc\/(\d+)/i;
+
+    sameAs.forEach(reference => {
+        if (!reference || typeof reference !== 'object') return;
+
+        // Check @id field for OCLC URL
+        const idValue = reference['@id'];
+        if (idValue && typeof idValue === 'string') {
+            const match = idValue.match(oclcPattern);
+            if (match) {
+                oclcLinks.push({
+                    type: 'oclc',
+                    url: idValue,
+                    oclcNumber: match[1],
+                    displayName: 'OCLC WorldCat Link'
+                });
+            }
+        }
+    });
+
+    return oclcLinks;
+}
+
+/**
+ * Detects ARK identifiers from dcterms:identifier field
+ * Prefixes them with https://n2t.net/ to create complete URLs
+ * @param {Object} item - Omeka S item object
+ * @returns {Array} Array of ARK reference objects
+ */
+export function detectARKIdentifiers(item) {
+    const arkIdentifiers = [];
+
+    if (!item || !item['dcterms:identifier']) return arkIdentifiers;
+
+    const identifiers = item['dcterms:identifier'];
+    if (!Array.isArray(identifiers)) return arkIdentifiers;
+
+    // Pattern to match ARK identifiers
+    const arkPattern = /^ark:[\\/]?[0-9]+[\\/][0-9a-zA-Z._\-]+/i;
+
+    identifiers.forEach(identifier => {
+        if (!identifier || typeof identifier !== 'object') return;
+
+        // Check @value field for ARK identifier
+        const value = identifier['@value'];
+        if (value && typeof value === 'string') {
+            const match = value.match(arkPattern);
+            if (match) {
+                // Prefix ARK identifier with n2t.net resolver
+                const fullUrl = `https://n2t.net/${match[0]}`;
+                arkIdentifiers.push({
+                    type: 'ark',
+                    url: fullUrl,
+                    arkValue: match[0],
+                    displayName: 'ARK Identifier'
+                });
+            }
+        }
+    });
+
+    return arkIdentifiers;
+}
+
+/**
+ * Gets a human-readable label for a reference type
+ * @param {string} type - Reference type
+ * @returns {string} Display label
+ */
+export function getReferenceTypeLabel(type) {
+    const labels = {
+        'omeka-item': 'Omeka Item Links',
+        'oclc': 'OCLC WorldCat Links',
+        'ark': 'ARK Identifiers'
+    };
+    return labels[type] || type;
+}
+
+/**
+ * Gets a description for a reference type
+ * @param {string} type - Reference type
+ * @returns {string} Description
+ */
+export function getReferenceTypeDescription(type) {
+    const descriptions = {
+        'omeka-item': 'Direct links to Omeka S item API endpoints',
+        'oclc': 'OCLC WorldCat bibliographic control numbers',
+        'ark': 'Archival Resource Key persistent identifiers'
+    };
+    return descriptions[type] || '';
+}

--- a/src/js/references/core/detector.js
+++ b/src/js/references/core/detector.js
@@ -218,7 +218,7 @@ export function getReferenceTypeLabel(type) {
  */
 export function getReferenceTypeDescription(type) {
     const descriptions = {
-        'omeka-item': 'Link to the item through Omeka S',
+        'omeka-item': 'Link to the item through Omeka S API',
         'oclc': 'OCLC WorldCat bibliographic identifier',
         'ark': 'Archival Resource Key persistent identifier'
     };

--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -168,7 +168,8 @@ export function openCustomReferenceModal(state, onSubmit, options = {}) {
     // Create input field for each item
     const itemInputs = [];
     items.forEach((item, index) => {
-        const itemId = `item-${index}`;
+        // Use same itemId format as detector: @id or id or fallback to item-${index}
+        const itemId = item['@id'] || item.id || `item-${index}`;
         const displayName = getItemDisplayName(item, index, reconciliationData);
 
         const itemRow = createElement('div', {

--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -261,34 +261,37 @@ export function openCustomReferenceModal(state, onSubmit, options = {}) {
                 return;
             }
 
-            // Create or update reference
+            // Create or update reference - ALWAYS use createCustomReference for complete objects
             try {
+                let customRef;
+
                 if (isEdit && existingReference) {
-                    // Return updated data with ID for state update
-                    const updatedData = {
+                    // Preserve existing metadata when editing
+                    const options = {
                         id: existingReference.id,
-                        name,
-                        items: itemReferences.filter(item => item.url !== '')
+                        createdAt: existingReference.createdAt
                     };
 
-                    // Close modal
-                    document.body.removeChild(overlay);
-
-                    // Call onSubmit callback with updated data
-                    if (onSubmit) {
-                        onSubmit(updatedData);
+                    // If this was originally an auto-detected reference, preserve that info
+                    if (existingReference.originalType) {
+                        options.originalType = existingReference.originalType;
+                    } else if (existingReference.isAutoDetected) {
+                        // First time converting from auto-detected
+                        options.originalType = existingReference.type;
                     }
+
+                    customRef = createCustomReference(name, itemReferences, options);
                 } else {
-                    // Create new custom reference
-                    const customRef = createCustomReference(name, itemReferences);
+                    // Create brand new custom reference
+                    customRef = createCustomReference(name, itemReferences);
+                }
 
-                    // Close modal
-                    document.body.removeChild(overlay);
+                // Close modal
+                document.body.removeChild(overlay);
 
-                    // Call onSubmit callback
-                    if (onSubmit) {
-                        onSubmit(customRef);
-                    }
+                // Call onSubmit callback with complete reference object
+                if (onSubmit) {
+                    onSubmit(customRef);
                 }
             } catch (error) {
                 errorContainer.textContent = error.message;

--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -1,0 +1,304 @@
+/**
+ * Custom Reference Modal UI Module
+ * Handles the modal interface for adding custom references
+ * @module references/ui/custom-reference-modal
+ */
+
+import { createElement, createButton, createInput } from '../../ui/components.js';
+import { createCustomReference, validateCustomReference } from '../core/custom-references.js';
+
+/**
+ * Gets the display name for an item based on reconciliation status
+ * @param {Object} item - The Omeka item
+ * @param {number} index - Item index
+ * @param {Object} reconciliationData - Reconciliation data from state
+ * @returns {string} Display name for the item
+ */
+function getItemDisplayName(item, index, reconciliationData) {
+    const itemId = `item-${index}`;
+    const itemData = reconciliationData?.[itemId];
+
+    // Check if item has a linked Wikidata QID
+    if (itemData && itemData.properties) {
+        // Look through properties to find a reconciled Wikidata item
+        for (const propertyKey in itemData.properties) {
+            const propertyData = itemData.properties[propertyKey];
+            if (propertyData.reconciled && Array.isArray(propertyData.reconciled)) {
+                for (const reconciledItem of propertyData.reconciled) {
+                    if (reconciledItem.selectedMatch && reconciledItem.selectedMatch.type === 'wikidata') {
+                        return `Linked QID: ${reconciledItem.selectedMatch.id}`;
+                    }
+                }
+            }
+        }
+    }
+
+    // No linked QID found, show as new item
+    return `New item ${index + 1}`;
+}
+
+/**
+ * Creates and opens the custom reference modal
+ * @param {Object} state - Application state management instance
+ * @param {Function} onSubmit - Callback function when reference is added
+ */
+export function openCustomReferenceModal(state, onSubmit) {
+    const currentState = state.getState();
+    const items = currentState.fetchedData || [];
+    const reconciliationData = currentState.reconciliationData || {};
+
+    // Create modal overlay
+    const overlay = createElement('div', {
+        className: 'modal-overlay',
+        style: {
+            position: 'fixed',
+            top: '0',
+            left: '0',
+            width: '100%',
+            height: '100%',
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: '1000'
+        }
+    });
+
+    // Create modal container
+    const modal = createElement('div', {
+        className: 'modal custom-reference-modal',
+        style: {
+            backgroundColor: 'white',
+            borderRadius: '8px',
+            padding: '24px',
+            maxWidth: '600px',
+            maxHeight: '80vh',
+            overflow: 'auto',
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
+        }
+    });
+
+    // Create modal header
+    const header = createElement('div', {
+        className: 'modal-header',
+        style: {
+            marginBottom: '16px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center'
+        }
+    });
+
+    const title = createElement('h3', {
+        style: { margin: '0' }
+    }, 'Custom Reference');
+
+    const closeButton = createButton('×', {
+        className: 'close-button',
+        style: {
+            background: 'none',
+            border: 'none',
+            fontSize: '24px',
+            cursor: 'pointer',
+            padding: '0',
+            width: '32px',
+            height: '32px'
+        },
+        onClick: () => {
+            document.body.removeChild(overlay);
+        }
+    });
+
+    header.appendChild(title);
+    header.appendChild(closeButton);
+
+    // Create modal body
+    const body = createElement('div', {
+        className: 'modal-body'
+    });
+
+    // Reference name input
+    const nameLabel = createElement('label', {
+        style: {
+            display: 'block',
+            marginBottom: '8px',
+            fontWeight: '500'
+        }
+    }, 'Reference Name');
+
+    const nameInput = createInput('text', {
+        placeholder: 'custom reference',
+        style: {
+            width: '100%',
+            padding: '8px',
+            marginBottom: '16px',
+            border: '1px solid #ddd',
+            borderRadius: '4px'
+        }
+    });
+
+    // Description
+    const description = createElement('p', {
+        style: {
+            marginBottom: '16px',
+            color: '#666',
+            fontSize: '14px'
+        }
+    }, 'Add a reference URL for each item. Leave empty if no reference exists for that item.');
+
+    // Items container
+    const itemsContainer = createElement('div', {
+        className: 'items-container',
+        style: {
+            marginTop: '16px'
+        }
+    });
+
+    // Create input field for each item
+    const itemInputs = [];
+    items.forEach((item, index) => {
+        const itemId = `item-${index}`;
+        const displayName = getItemDisplayName(item, index, reconciliationData);
+
+        const itemRow = createElement('div', {
+            className: 'item-row',
+            style: {
+                marginBottom: '12px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px'
+            }
+        });
+
+        const itemLabel = createElement('label', {
+            style: {
+                minWidth: '150px',
+                fontSize: '14px',
+                fontWeight: '500'
+            }
+        }, displayName);
+
+        const itemInput = createInput('text', {
+            placeholder: 'https://example.com/reference',
+            dataset: { itemId },
+            style: {
+                flex: '1',
+                padding: '6px 8px',
+                border: '1px solid #ddd',
+                borderRadius: '4px',
+                fontSize: '14px'
+            }
+        });
+
+        itemInputs.push({ itemId, input: itemInput });
+
+        itemRow.appendChild(itemLabel);
+        itemRow.appendChild(itemInput);
+        itemsContainer.appendChild(itemRow);
+    });
+
+    // Error message container
+    const errorContainer = createElement('div', {
+        className: 'error-container',
+        style: {
+            marginTop: '12px',
+            color: '#f44336',
+            fontSize: '14px',
+            display: 'none'
+        }
+    });
+
+    // Create modal footer with buttons
+    const footer = createElement('div', {
+        className: 'modal-footer',
+        style: {
+            marginTop: '24px',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '8px'
+        }
+    });
+
+    const cancelButton = createButton('Cancel', {
+        className: 'button button--secondary',
+        onClick: () => {
+            document.body.removeChild(overlay);
+        }
+    });
+
+    const addButton = createButton('Add Reference', {
+        className: 'button button--primary',
+        onClick: () => {
+            // Gather input values
+            const name = nameInput.value.trim() || 'Custom reference';
+            const itemReferences = itemInputs
+                .map(({ itemId, input }) => ({
+                    itemId,
+                    url: input.value.trim()
+                }))
+                .filter(item => item.url !== ''); // Only include items with URLs
+
+            // Validate
+            const validation = validateCustomReference(name, itemReferences);
+            if (!validation.isValid) {
+                errorContainer.textContent = validation.errors.join('. ');
+                errorContainer.style.display = 'block';
+                return;
+            }
+
+            // Create custom reference
+            try {
+                const customRef = createCustomReference(name, itemReferences);
+
+                // Close modal
+                document.body.removeChild(overlay);
+
+                // Call onSubmit callback
+                if (onSubmit) {
+                    onSubmit(customRef);
+                }
+            } catch (error) {
+                errorContainer.textContent = error.message;
+                errorContainer.style.display = 'block';
+            }
+        }
+    });
+
+    footer.appendChild(cancelButton);
+    footer.appendChild(addButton);
+
+    // Assemble modal
+    body.appendChild(nameLabel);
+    body.appendChild(nameInput);
+    body.appendChild(description);
+    body.appendChild(itemsContainer);
+    body.appendChild(errorContainer);
+
+    modal.appendChild(header);
+    modal.appendChild(body);
+    modal.appendChild(footer);
+
+    overlay.appendChild(modal);
+
+    // Add to document
+    document.body.appendChild(overlay);
+
+    // Focus on name input
+    setTimeout(() => nameInput.focus(), 100);
+
+    // Close on overlay click
+    overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) {
+            document.body.removeChild(overlay);
+        }
+    });
+
+    // Close on Escape key
+    const handleEscape = (e) => {
+        if (e.key === 'Escape') {
+            document.body.removeChild(overlay);
+            document.removeEventListener('keydown', handleEscape);
+        }
+    };
+    document.addEventListener('keydown', handleEscape);
+}

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -191,14 +191,14 @@ export function createTooltip(examples, type) {
         }
     });
 
-    // Create list of examples (no header)
+    // Create list of examples (no header, no bullets)
     const list = createElement('ul', {
         className: 'tooltip-examples-list',
         style: {
             margin: '0',
-            padding: '0 0 0 20px',
+            padding: '0',
             fontSize: '11px',
-            listStyle: 'disc'
+            listStyle: 'none'
         }
     });
 
@@ -206,13 +206,30 @@ export function createTooltip(examples, type) {
         const listItem = createElement('li', {
             style: {
                 marginBottom: '4px',
-                wordBreak: 'break-all',
-                color: '#666'
+                wordBreak: 'break-all'
             }
         });
 
-        // Display full URL without truncation
-        listItem.textContent = example.value;
+        // Create clickable link
+        const link = createElement('a', {
+            href: example.value,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            style: {
+                color: '#0066cc',
+                textDecoration: 'none'
+            }
+        }, example.value);
+
+        // Add hover effect
+        link.addEventListener('mouseenter', () => {
+            link.style.textDecoration = 'underline';
+        });
+        link.addEventListener('mouseleave', () => {
+            link.style.textDecoration = 'none';
+        });
+
+        listItem.appendChild(link);
         list.appendChild(listItem);
     });
 

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -6,6 +6,7 @@
 
 import { createElement } from '../../ui/components.js';
 import { getReferenceTypeLabel, getReferenceTypeDescription } from '../core/detector.js';
+import { getDisplayBaseUrl } from '../core/custom-references.js';
 
 /**
  * Renders the references section in the UI
@@ -124,6 +125,11 @@ export function createReferenceListItem(type, data, totalItems, state = null) {
 
     // Create list item (uses same classes as mapping lists)
     const listItem = createElement('li', {
+        dataset: {
+            action: 'edit-reference',
+            referenceType: 'auto-detected',
+            referenceId: type
+        },
         style: {
             opacity: isSelected ? '1' : '0.5',
             transition: 'opacity 0.2s ease'
@@ -137,7 +143,8 @@ export function createReferenceListItem(type, data, totalItems, state = null) {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            width: '100%'
+            width: '100%',
+            cursor: 'pointer'
         }
     });
 
@@ -224,9 +231,15 @@ export function createReferenceListItem(type, data, totalItems, state = null) {
         tooltip.style.display = 'none';
     });
 
+    // Prevent info icon clicks from triggering edit
+    infoIcon.addEventListener('click', (e) => {
+        e.stopPropagation();
+    });
+
     // Add click handler to toggle selection state
     if (state) {
-        status.addEventListener('click', () => {
+        status.addEventListener('click', (e) => {
+            e.stopPropagation(); // Prevent edit modal from opening
             state.toggleReferenceType(type);
             const newIsSelected = state.isReferenceTypeSelected(type);
 
@@ -351,7 +364,7 @@ export function updateReferencesDisplay(summary, container, totalItems = 0, stat
  */
 export function createCustomReferenceListItem(customRef, data, totalItems, state = null) {
     const label = customRef.name;
-    const description = customRef.baseUrl;
+    const description = getDisplayBaseUrl(customRef.baseUrl); // Remove https://
     const type = customRef.id;
 
     // Check if this type is selected (default to selected if no state)
@@ -359,6 +372,11 @@ export function createCustomReferenceListItem(customRef, data, totalItems, state
 
     // Create list item (uses same classes as mapping lists)
     const listItem = createElement('li', {
+        dataset: {
+            action: 'edit-reference',
+            referenceType: 'custom',
+            referenceId: customRef.id
+        },
         style: {
             opacity: isSelected ? '1' : '0.5',
             transition: 'opacity 0.2s ease'
@@ -372,7 +390,8 @@ export function createCustomReferenceListItem(customRef, data, totalItems, state
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            width: '100%'
+            width: '100%',
+            cursor: 'pointer'
         }
     });
 
@@ -459,9 +478,15 @@ export function createCustomReferenceListItem(customRef, data, totalItems, state
         tooltip.style.display = 'none';
     });
 
+    // Prevent info icon clicks from triggering edit
+    infoIcon.addEventListener('click', (e) => {
+        e.stopPropagation();
+    });
+
     // Add click handler to toggle selection state
     if (state) {
-        status.addEventListener('click', () => {
+        status.addEventListener('click', (e) => {
+            e.stopPropagation(); // Prevent edit modal from opening
             state.toggleReferenceType(type);
             const newIsSelected = state.isReferenceTypeSelected(type);
 
@@ -506,9 +531,7 @@ export function createAddCustomReferenceButton(state) {
         className: 'add-custom-reference-button',
         style: {
             cursor: 'pointer',
-            padding: '8px 12px',
-            borderTop: '1px solid #eee',
-            marginTop: '8px'
+            padding: '8px 12px'
         }
     });
 
@@ -516,14 +539,12 @@ export function createAddCustomReferenceButton(state) {
         style: {
             display: 'flex',
             alignItems: 'center',
-            gap: '8px',
-            color: '#0066cc'
+            gap: '8px'
         }
     });
 
     const plusIcon = createElement('span', {
         style: {
-            fontSize: '1.2em',
             fontWeight: 'bold'
         }
     }, '+');

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -35,13 +35,22 @@ export function renderReferencesSection(summary, container, totalItems = 0) {
 
     // Create title
     const title = createElement('h3', {
-        className: 'references-title'
+        className: 'references-title',
+        style: {
+            textAlign: 'left',
+            marginBottom: '16px'
+        }
     }, 'Available References');
     container.appendChild(title);
 
     // Create list
     const list = createElement('ul', {
-        className: 'references-list'
+        className: 'references-list',
+        style: {
+            textAlign: 'left',
+            listStylePosition: 'inside',
+            paddingLeft: '0'
+        }
     });
 
     // Create reference type list items
@@ -74,7 +83,8 @@ export function createReferenceListItem(type, data, totalItems) {
         className: 'reference-list-item',
         style: {
             position: 'relative',
-            marginBottom: '8px'
+            marginBottom: '8px',
+            textAlign: 'left'
         }
     });
 

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -11,8 +11,9 @@ import { getReferenceTypeLabel, getReferenceTypeDescription } from '../core/dete
  * Renders the references section in the UI
  * @param {Object} summary - Reference summary with counts and examples
  * @param {HTMLElement} container - Container element to render into
+ * @param {number} totalItems - Total number of items in dataset
  */
-export function renderReferencesSection(summary, container) {
+export function renderReferencesSection(summary, container, totalItems = 0) {
     if (!container) {
         console.error('No container provided for references section');
         return;
@@ -32,50 +33,74 @@ export function renderReferencesSection(summary, container) {
         return;
     }
 
-    // Create reference type cards
+    // Create title
+    const title = createElement('h3', {
+        className: 'references-title'
+    }, 'Available References');
+    container.appendChild(title);
+
+    // Create list
+    const list = createElement('ul', {
+        className: 'references-list'
+    });
+
+    // Create reference type list items
     const referenceTypes = ['omeka-item', 'oclc', 'ark'];
 
     referenceTypes.forEach(type => {
         const data = summary[type];
         if (data && data.count > 0) {
-            const card = createReferenceTypeCard(type, data);
-            container.appendChild(card);
+            const listItem = createReferenceListItem(type, data, totalItems);
+            list.appendChild(listItem);
         }
     });
+
+    container.appendChild(list);
 }
 
 /**
- * Creates a card displaying a reference type with count and tooltip
+ * Creates a list item displaying a reference type with count and tooltip
  * @param {string} type - Reference type
  * @param {Object} data - Reference data with count and examples
- * @returns {HTMLElement} Card element
+ * @param {number} totalItems - Total number of items in dataset
+ * @returns {HTMLElement} List item element
  */
-export function createReferenceTypeCard(type, data) {
+export function createReferenceListItem(type, data, totalItems) {
     const label = getReferenceTypeLabel(type);
     const description = getReferenceTypeDescription(type);
 
-    // Create card container
-    const card = createElement('div', {
-        className: 'reference-type-card'
+    // Create list item
+    const listItem = createElement('li', {
+        className: 'reference-list-item',
+        style: {
+            position: 'relative',
+            marginBottom: '8px'
+        }
     });
 
-    // Create header with label and count
-    const header = createElement('div', {
-        className: 'reference-type-header'
-    });
+    // Create text content: "Label (count/total items) - Description"
+    const textContent = `${label} (${data.count}/${totalItems} items) - ${description}`;
 
-    const titleSpan = createElement('span', {
-        className: 'reference-type-title'
-    }, `${label} (${data.count} ${data.count === 1 ? 'item' : 'items'})`);
+    const textSpan = createElement('span', {
+        className: 'reference-text'
+    }, textContent);
 
     // Create info icon with tooltip
     const infoIcon = createElement('span', {
         className: 'reference-info-icon',
-        title: 'Hover for examples'
+        title: 'Hover for examples',
+        style: {
+            marginLeft: '8px',
+            cursor: 'pointer',
+            color: '#0066cc'
+        }
     }, 'ⓘ');
 
     // Create tooltip element
     const tooltip = createTooltip(data.examples, type);
+
+    // Add tooltip to body for proper positioning
+    document.body.appendChild(tooltip);
 
     // Add hover handlers for tooltip
     let hideTimeout;
@@ -84,11 +109,10 @@ export function createReferenceTypeCard(type, data) {
         clearTimeout(hideTimeout);
         tooltip.style.display = 'block';
 
-        // Position tooltip near the icon
+        // Position tooltip near the icon using fixed positioning
         const iconRect = infoIcon.getBoundingClientRect();
-        const cardRect = card.getBoundingClientRect();
-        tooltip.style.left = `${iconRect.left - cardRect.left + 20}px`;
-        tooltip.style.top = `${iconRect.top - cardRect.top - 10}px`;
+        tooltip.style.left = `${iconRect.right + 10}px`;
+        tooltip.style.top = `${iconRect.top}px`;
     });
 
     infoIcon.addEventListener('mouseleave', () => {
@@ -106,20 +130,10 @@ export function createReferenceTypeCard(type, data) {
         tooltip.style.display = 'none';
     });
 
-    header.appendChild(titleSpan);
-    header.appendChild(infoIcon);
+    listItem.appendChild(textSpan);
+    listItem.appendChild(infoIcon);
 
-    // Create description
-    const descDiv = createElement('div', {
-        className: 'reference-type-description'
-    }, description);
-
-    // Assemble card
-    card.appendChild(header);
-    card.appendChild(descDiv);
-    card.appendChild(tooltip);
-
-    return card;
+    return listItem;
 }
 
 /**
@@ -133,7 +147,7 @@ export function createTooltip(examples, type) {
         className: 'reference-tooltip',
         style: {
             display: 'none',
-            position: 'absolute',
+            position: 'fixed',
             zIndex: '1000',
             backgroundColor: '#fff',
             border: '1px solid #ccc',
@@ -195,7 +209,8 @@ export function createTooltip(examples, type) {
  * Updates the references display with new summary data
  * @param {Object} summary - Updated reference summary
  * @param {HTMLElement} container - Container element
+ * @param {number} totalItems - Total number of items in dataset
  */
-export function updateReferencesDisplay(summary, container) {
-    renderReferencesSection(summary, container);
+export function updateReferencesDisplay(summary, container, totalItems = 0) {
+    renderReferencesSection(summary, container, totalItems);
 }

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -48,7 +48,11 @@ export function renderReferencesSection(summary, container, totalItems = 0) {
     });
 
     // Create summary (header)
-    const summaryElement = createElement('summary');
+    const summaryElement = createElement('summary', {
+        style: {
+            textAlign: 'left'
+        }
+    });
 
     const titleSpan = createElement('span', {
         className: 'section-title'
@@ -182,25 +186,12 @@ export function createTooltip(examples, type) {
             border: '1px solid #ccc',
             borderRadius: '4px',
             padding: '10px',
-            maxWidth: '400px',
+            maxWidth: '700px',
             boxShadow: '0 2px 8px rgba(0,0,0,0.15)'
         }
     });
 
-    // Create header
-    const header = createElement('div', {
-        className: 'tooltip-header',
-        style: {
-            fontWeight: 'bold',
-            marginBottom: '8px',
-            fontSize: '12px',
-            color: '#333'
-        }
-    }, `Example values (showing up to ${examples.length})`);
-
-    tooltip.appendChild(header);
-
-    // Create list of examples
+    // Create list of examples (no header)
     const list = createElement('ul', {
         className: 'tooltip-examples-list',
         style: {
@@ -220,12 +211,8 @@ export function createTooltip(examples, type) {
             }
         });
 
-        // Truncate long URLs for display
-        const displayValue = example.value.length > 60
-            ? example.value.substring(0, 60) + '...'
-            : example.value;
-
-        listItem.textContent = displayValue;
+        // Display full URL without truncation
+        listItem.textContent = example.value;
         list.appendChild(listItem);
     });
 

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -33,24 +33,38 @@ export function renderReferencesSection(summary, container, totalItems = 0) {
         return;
     }
 
-    // Create title
-    const title = createElement('h3', {
-        className: 'references-title',
-        style: {
-            textAlign: 'left',
-            marginBottom: '16px'
+    // Calculate total items with at least one reference
+    const itemsWithReferences = new Set();
+    Object.values(summary).forEach(data => {
+        if (data.examples) {
+            data.examples.forEach(example => itemsWithReferences.add(example.itemId));
         }
+    });
+
+    // Create section (details element)
+    const section = createElement('details', {
+        className: 'section',
+        open: true
+    });
+
+    // Create summary (header)
+    const summaryElement = createElement('summary');
+
+    const titleSpan = createElement('span', {
+        className: 'section-title'
     }, 'Available References');
-    container.appendChild(title);
+
+    const countSpan = createElement('span', {
+        className: 'section-count'
+    }, `(${itemsWithReferences.size}/${totalItems})`);
+
+    summaryElement.appendChild(titleSpan);
+    summaryElement.appendChild(countSpan);
+    section.appendChild(summaryElement);
 
     // Create list
     const list = createElement('ul', {
-        className: 'references-list',
-        style: {
-            textAlign: 'left',
-            listStylePosition: 'inside',
-            paddingLeft: '0'
-        }
+        className: 'key-list'
     });
 
     // Create reference type list items
@@ -64,7 +78,8 @@ export function renderReferencesSection(summary, container, totalItems = 0) {
         }
     });
 
-    container.appendChild(list);
+    section.appendChild(list);
+    container.appendChild(section);
 }
 
 /**
@@ -78,24 +93,20 @@ export function createReferenceListItem(type, data, totalItems) {
     const label = getReferenceTypeLabel(type);
     const description = getReferenceTypeDescription(type);
 
-    // Create list item
-    const listItem = createElement('li', {
-        className: 'reference-list-item',
-        style: {
-            position: 'relative',
-            marginBottom: '8px',
-            textAlign: 'left'
-        }
+    // Create list item (uses same classes as mapping lists)
+    const listItem = createElement('li');
+
+    // Create compact key item wrapper
+    const keyItemCompact = createElement('div', {
+        className: 'key-item-compact'
     });
 
-    // Create text content: "Label (count/total items) - Description"
-    const textContent = `${label} (${data.count}/${totalItems} items) - ${description}`;
+    // Create key name with label and description
+    const keyName = createElement('span', {
+        className: 'key-name-compact'
+    }, `${label} - ${description}`);
 
-    const textSpan = createElement('span', {
-        className: 'reference-text'
-    }, textContent);
-
-    // Create info icon with tooltip
+    // Create info icon with tooltip (inline with text)
     const infoIcon = createElement('span', {
         className: 'reference-info-icon',
         title: 'Hover for examples',
@@ -105,6 +116,11 @@ export function createReferenceListItem(type, data, totalItems) {
             color: '#0066cc'
         }
     }, 'ⓘ');
+
+    // Create frequency indicator (count display)
+    const frequency = createElement('span', {
+        className: 'key-frequency'
+    }, `(${data.count}/${totalItems})`);
 
     // Create tooltip element
     const tooltip = createTooltip(data.examples, type);
@@ -140,8 +156,11 @@ export function createReferenceListItem(type, data, totalItems) {
         tooltip.style.display = 'none';
     });
 
-    listItem.appendChild(textSpan);
-    listItem.appendChild(infoIcon);
+    // Append all elements in the correct order
+    keyItemCompact.appendChild(keyName);
+    keyItemCompact.appendChild(infoIcon);
+    keyItemCompact.appendChild(frequency);
+    listItem.appendChild(keyItemCompact);
 
     return listItem;
 }

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -83,6 +83,26 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
         }
     });
 
+    // Add custom references
+    if (state) {
+        const customReferences = state.getCustomReferences();
+        customReferences.forEach(customRef => {
+            const data = {
+                count: customRef.count,
+                examples: customRef.items.slice(0, 10).map(item => ({
+                    itemId: item.itemId,
+                    value: item.url
+                }))
+            };
+            const listItem = createCustomReferenceListItem(customRef, data, totalItems, state);
+            list.appendChild(listItem);
+        });
+    }
+
+    // Add "Add custom reference" button as a list item
+    const addButton = createAddCustomReferenceButton(state);
+    list.appendChild(addButton);
+
     section.appendChild(list);
     container.appendChild(section);
 }
@@ -319,4 +339,212 @@ export function createTooltip(examples, type) {
  */
 export function updateReferencesDisplay(summary, container, totalItems = 0, state = null) {
     renderReferencesSection(summary, container, totalItems, state);
+}
+
+/**
+ * Creates a list item for a custom reference
+ * @param {Object} customRef - Custom reference object
+ * @param {Object} data - Reference data with count and examples
+ * @param {number} totalItems - Total number of items in dataset
+ * @param {Object} state - Application state management instance
+ * @returns {HTMLElement} List item element
+ */
+export function createCustomReferenceListItem(customRef, data, totalItems, state = null) {
+    const label = customRef.name;
+    const description = customRef.baseUrl;
+    const type = customRef.id;
+
+    // Check if this type is selected (default to selected if no state)
+    const isSelected = state ? state.isReferenceTypeSelected(type) : true;
+
+    // Create list item (uses same classes as mapping lists)
+    const listItem = createElement('li', {
+        style: {
+            opacity: isSelected ? '1' : '0.5',
+            transition: 'opacity 0.2s ease'
+        }
+    });
+
+    // Create compact key item wrapper
+    const keyItemCompact = createElement('div', {
+        className: 'key-item-compact',
+        style: {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%'
+        }
+    });
+
+    // Create left section (text + frequency + info icon)
+    const leftSection = createElement('div', {
+        style: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px'
+        }
+    });
+
+    // Create key name with label and description
+    const keyName = createElement('span', {
+        className: 'key-name-compact',
+        style: {
+            textDecoration: isSelected ? 'none' : 'line-through'
+        }
+    }, `${label} - ${description}`);
+
+    // Create frequency indicator (count display)
+    const frequency = createElement('span', {
+        className: 'key-frequency',
+        style: {
+            fontSize: '0.9em',
+            color: '#666'
+        }
+    }, `${data.count}/${totalItems} items`);
+
+    // Create info icon with tooltip
+    const infoIcon = createElement('span', {
+        className: 'reference-info-icon',
+        title: 'Hover for examples',
+        style: {
+            cursor: 'pointer',
+            color: '#0066cc',
+            fontSize: '1.1em'
+        }
+    }, 'ⓘ');
+
+    // Create status indicator on the right
+    const status = createElement('span', {
+        className: 'reference-status',
+        style: {
+            fontSize: '0.85em',
+            fontWeight: '500',
+            color: isSelected ? '#2ecc71' : '#95a5a6',
+            cursor: 'pointer',
+            userSelect: 'none'
+        }
+    }, isSelected ? 'Selected' : 'Ignored');
+
+    // Create tooltip element
+    const tooltip = createTooltip(data.examples, type);
+
+    // Add tooltip to body for proper positioning
+    document.body.appendChild(tooltip);
+
+    // Add hover handlers for tooltip
+    let hideTimeout;
+
+    infoIcon.addEventListener('mouseenter', () => {
+        clearTimeout(hideTimeout);
+        tooltip.style.display = 'block';
+
+        // Position tooltip near the icon using fixed positioning
+        const iconRect = infoIcon.getBoundingClientRect();
+        tooltip.style.left = `${iconRect.right + 10}px`;
+        tooltip.style.top = `${iconRect.top}px`;
+    });
+
+    infoIcon.addEventListener('mouseleave', () => {
+        hideTimeout = setTimeout(() => {
+            tooltip.style.display = 'none';
+        }, 200);
+    });
+
+    // Keep tooltip visible when hovering over it
+    tooltip.addEventListener('mouseenter', () => {
+        clearTimeout(hideTimeout);
+    });
+
+    tooltip.addEventListener('mouseleave', () => {
+        tooltip.style.display = 'none';
+    });
+
+    // Add click handler to toggle selection state
+    if (state) {
+        status.addEventListener('click', () => {
+            state.toggleReferenceType(type);
+            const newIsSelected = state.isReferenceTypeSelected(type);
+
+            // Update visual state
+            listItem.style.opacity = newIsSelected ? '1' : '0.5';
+            keyName.style.textDecoration = newIsSelected ? 'none' : 'line-through';
+            status.textContent = newIsSelected ? 'Selected' : 'Ignored';
+            status.style.color = newIsSelected ? '#2ecc71' : '#95a5a6';
+        });
+
+        // Add hover effect to status
+        status.addEventListener('mouseenter', () => {
+            status.style.textDecoration = 'underline';
+        });
+
+        status.addEventListener('mouseleave', () => {
+            status.style.textDecoration = 'none';
+        });
+    }
+
+    // Append all elements in the correct order: text -> frequency -> info icon
+    leftSection.appendChild(keyName);
+    leftSection.appendChild(frequency);
+    leftSection.appendChild(infoIcon);
+
+    // Append left section and status to the wrapper
+    keyItemCompact.appendChild(leftSection);
+    keyItemCompact.appendChild(status);
+
+    listItem.appendChild(keyItemCompact);
+
+    return listItem;
+}
+
+/**
+ * Creates the "Add custom reference" button as a list item
+ * @param {Object} state - Application state management instance
+ * @returns {HTMLElement} Button list item element
+ */
+export function createAddCustomReferenceButton(state) {
+    const listItem = createElement('li', {
+        className: 'add-custom-reference-button',
+        style: {
+            cursor: 'pointer',
+            padding: '8px 12px',
+            borderTop: '1px solid #eee',
+            marginTop: '8px'
+        }
+    });
+
+    const content = createElement('div', {
+        style: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            color: '#0066cc'
+        }
+    });
+
+    const plusIcon = createElement('span', {
+        style: {
+            fontSize: '1.2em',
+            fontWeight: 'bold'
+        }
+    }, '+');
+
+    const text = createElement('span', {}, 'Add custom reference');
+
+    content.appendChild(plusIcon);
+    content.appendChild(text);
+    listItem.appendChild(content);
+
+    // Add hover effect
+    listItem.addEventListener('mouseenter', () => {
+        listItem.style.backgroundColor = '#f5f5f5';
+    });
+
+    listItem.addEventListener('mouseleave', () => {
+        listItem.style.backgroundColor = 'transparent';
+    });
+
+    // Store click handler data attribute for step4.js to attach handler
+    listItem.dataset.action = 'add-custom-reference';
+
+    return listItem;
 }

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -1,0 +1,201 @@
+/**
+ * Reference Display Module
+ * Renders detected references with counts and example tooltips
+ * @module references/ui/display
+ */
+
+import { createElement } from '../../ui/components.js';
+import { getReferenceTypeLabel, getReferenceTypeDescription } from '../core/detector.js';
+
+/**
+ * Renders the references section in the UI
+ * @param {Object} summary - Reference summary with counts and examples
+ * @param {HTMLElement} container - Container element to render into
+ */
+export function renderReferencesSection(summary, container) {
+    if (!container) {
+        console.error('No container provided for references section');
+        return;
+    }
+
+    // Clear existing content
+    container.innerHTML = '';
+
+    // Check if there are any references
+    const hasReferences = Object.values(summary).some(data => data.count > 0);
+
+    if (!hasReferences) {
+        const emptyMessage = createElement('p', {
+            className: 'placeholder'
+        }, 'No references detected in the API data.');
+        container.appendChild(emptyMessage);
+        return;
+    }
+
+    // Create reference type cards
+    const referenceTypes = ['omeka-item', 'oclc', 'ark'];
+
+    referenceTypes.forEach(type => {
+        const data = summary[type];
+        if (data && data.count > 0) {
+            const card = createReferenceTypeCard(type, data);
+            container.appendChild(card);
+        }
+    });
+}
+
+/**
+ * Creates a card displaying a reference type with count and tooltip
+ * @param {string} type - Reference type
+ * @param {Object} data - Reference data with count and examples
+ * @returns {HTMLElement} Card element
+ */
+export function createReferenceTypeCard(type, data) {
+    const label = getReferenceTypeLabel(type);
+    const description = getReferenceTypeDescription(type);
+
+    // Create card container
+    const card = createElement('div', {
+        className: 'reference-type-card'
+    });
+
+    // Create header with label and count
+    const header = createElement('div', {
+        className: 'reference-type-header'
+    });
+
+    const titleSpan = createElement('span', {
+        className: 'reference-type-title'
+    }, `${label} (${data.count} ${data.count === 1 ? 'item' : 'items'})`);
+
+    // Create info icon with tooltip
+    const infoIcon = createElement('span', {
+        className: 'reference-info-icon',
+        title: 'Hover for examples'
+    }, 'ⓘ');
+
+    // Create tooltip element
+    const tooltip = createTooltip(data.examples, type);
+
+    // Add hover handlers for tooltip
+    let hideTimeout;
+
+    infoIcon.addEventListener('mouseenter', () => {
+        clearTimeout(hideTimeout);
+        tooltip.style.display = 'block';
+
+        // Position tooltip near the icon
+        const iconRect = infoIcon.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+        tooltip.style.left = `${iconRect.left - cardRect.left + 20}px`;
+        tooltip.style.top = `${iconRect.top - cardRect.top - 10}px`;
+    });
+
+    infoIcon.addEventListener('mouseleave', () => {
+        hideTimeout = setTimeout(() => {
+            tooltip.style.display = 'none';
+        }, 200);
+    });
+
+    // Keep tooltip visible when hovering over it
+    tooltip.addEventListener('mouseenter', () => {
+        clearTimeout(hideTimeout);
+    });
+
+    tooltip.addEventListener('mouseleave', () => {
+        tooltip.style.display = 'none';
+    });
+
+    header.appendChild(titleSpan);
+    header.appendChild(infoIcon);
+
+    // Create description
+    const descDiv = createElement('div', {
+        className: 'reference-type-description'
+    }, description);
+
+    // Assemble card
+    card.appendChild(header);
+    card.appendChild(descDiv);
+    card.appendChild(tooltip);
+
+    return card;
+}
+
+/**
+ * Creates a tooltip element with example reference values
+ * @param {Array} examples - Array of example objects with itemId and value
+ * @param {string} type - Reference type for styling
+ * @returns {HTMLElement} Tooltip element
+ */
+export function createTooltip(examples, type) {
+    const tooltip = createElement('div', {
+        className: 'reference-tooltip',
+        style: {
+            display: 'none',
+            position: 'absolute',
+            zIndex: '1000',
+            backgroundColor: '#fff',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            padding: '10px',
+            maxWidth: '400px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)'
+        }
+    });
+
+    // Create header
+    const header = createElement('div', {
+        className: 'tooltip-header',
+        style: {
+            fontWeight: 'bold',
+            marginBottom: '8px',
+            fontSize: '12px',
+            color: '#333'
+        }
+    }, `Example values (showing up to ${examples.length})`);
+
+    tooltip.appendChild(header);
+
+    // Create list of examples
+    const list = createElement('ul', {
+        className: 'tooltip-examples-list',
+        style: {
+            margin: '0',
+            padding: '0 0 0 20px',
+            fontSize: '11px',
+            listStyle: 'disc'
+        }
+    });
+
+    examples.slice(0, 10).forEach(example => {
+        const listItem = createElement('li', {
+            style: {
+                marginBottom: '4px',
+                wordBreak: 'break-all',
+                color: '#666'
+            }
+        });
+
+        // Truncate long URLs for display
+        const displayValue = example.value.length > 60
+            ? example.value.substring(0, 60) + '...'
+            : example.value;
+
+        listItem.textContent = displayValue;
+        list.appendChild(listItem);
+    });
+
+    tooltip.appendChild(list);
+
+    return tooltip;
+}
+
+/**
+ * Updates the references display with new summary data
+ * @param {Object} summary - Updated reference summary
+ * @param {HTMLElement} container - Container element
+ */
+export function updateReferencesDisplay(summary, container) {
+    renderReferencesSection(summary, container);
+}

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -75,7 +75,8 @@ export function setupState() {
         // Step 4: References
         references: {
             itemReferences: {}, // Map of itemId -> array of reference objects
-            summary: {} // Map of referenceType -> {count, examples: [{itemId, value}]}
+            summary: {}, // Map of referenceType -> {count, examples: [{itemId, value}]}
+            selectedTypes: ['omeka-item', 'oclc', 'ark'] // List of selected reference types (default: all selected)
         },
 
         // Step 5: Export
@@ -772,6 +773,44 @@ export function setupState() {
     
     
     /**
+     * Toggles a reference type between selected and ignored
+     * @param {string} type - Reference type to toggle (e.g., 'omeka-item', 'oclc', 'ark')
+     */
+    function toggleReferenceType(type) {
+        const oldSelectedTypes = [...state.references.selectedTypes];
+        const index = state.references.selectedTypes.indexOf(type);
+
+        if (index === -1) {
+            // Not selected, add it
+            state.references.selectedTypes.push(type);
+        } else {
+            // Already selected, remove it
+            state.references.selectedTypes.splice(index, 1);
+        }
+
+        state.hasUnsavedChanges = true;
+
+        // Notify listeners of the reference type toggle
+        eventSystem.publish(eventSystem.Events.STATE_CHANGED, {
+            path: 'references.selectedTypes',
+            oldValue: oldSelectedTypes,
+            newValue: [...state.references.selectedTypes]
+        });
+
+        // Persist state to localStorage
+        persistState();
+    }
+
+    /**
+     * Checks if a reference type is selected
+     * @param {string} type - Reference type to check
+     * @returns {boolean} True if the reference type is selected
+     */
+    function isReferenceTypeSelected(type) {
+        return state.references.selectedTypes.includes(type);
+    }
+
+    /**
      * Loads mock data for testing purposes
      * @param {Object} mockItems - Mock items data with items array
      * @param {Object} mockMapping - Mock mapping data with mappings object
@@ -1170,6 +1209,9 @@ export function setupState() {
         incrementReconciliationCompleted,
         incrementReconciliationSkipped,
         setReconciliationProgress,
+        // Convenience methods for references
+        toggleReferenceType,
+        isReferenceTypeSelected,
         // Convenience methods for Entity Schema
         setSelectedEntitySchema,
         getSelectedEntitySchema,

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -72,12 +72,12 @@ export function setupState() {
         },
         reconciliationData: [],
         
-        // Step 4: References (placeholder step - emptied)
-        references: [], // Deprecated - step 4 emptied
-        selectedExampleItem: '', // Deprecated - step 4 emptied
-        designerData: [], // Deprecated - step 4 emptied
-        globalReferences: [], // Deprecated - step 4 emptied
-        
+        // Step 4: References
+        references: {
+            itemReferences: {}, // Map of itemId -> array of reference objects
+            summary: {} // Map of referenceType -> {count, examples: [{itemId, value}]}
+        },
+
         // Step 5: Export
         quickStatements: '',
         exportTimestamp: null
@@ -171,8 +171,10 @@ export function setupState() {
             const reconciledCount = Object.keys(savedState.reconciliationData).length;
             summary.push(`• ${reconciledCount} item${reconciledCount > 1 ? 's' : ''} with reconciliation data`);
         }
-        if (savedState.references && savedState.references.length > 0) {
-            summary.push(`• ${savedState.references.length} reference${savedState.references.length > 1 ? 's' : ''} configured`);
+        if (savedState.references && savedState.references.itemReferences &&
+            Object.keys(savedState.references.itemReferences).length > 0) {
+            const refCount = Object.keys(savedState.references.itemReferences).length;
+            summary.push(`• ${refCount} item${refCount > 1 ? 's' : ''} with references`);
         }
         
         summaryEl.innerHTML = summary.length > 0 ? 

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -883,9 +883,9 @@ export function setupState() {
     /**
      * Updates an existing custom reference
      * @param {string} id - ID of the custom reference to update
-     * @param {Object} updatedData - Updated reference data {name, items}
+     * @param {Object} updatedReference - Complete reference object from createCustomReference
      */
-    function updateCustomReference(id, updatedData) {
+    function updateCustomReference(id, updatedReference) {
         if (!state.references.customReferences) {
             return;
         }
@@ -898,23 +898,9 @@ export function setupState() {
 
         const oldValue = [...state.references.customReferences];
 
-        // Update the reference with new data while preserving id and metadata
-        const existingRef = state.references.customReferences[index];
-
-        // Filter out items with empty URLs
-        const validItems = updatedData.items.filter(item => item.url && item.url.trim() !== '');
-
-        // Import extractBaseUrl from custom-references module for consistency
-        const baseUrl = validItems.length > 0 ? updatedData.items[0].url.match(/^(https?:\/\/[^\/]+)/)?.[0] || updatedData.items[0].url : existingRef.baseUrl;
-
-        state.references.customReferences[index] = {
-            ...existingRef,
-            name: updatedData.name || existingRef.name,
-            items: validItems,
-            baseUrl,
-            count: validItems.length,
-            updatedAt: new Date().toISOString()
-        };
+        // Replace with the complete updated reference object
+        // The modal now provides a complete reference via createCustomReference
+        state.references.customReferences[index] = updatedReference;
 
         state.hasUnsavedChanges = true;
 

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -16,6 +16,7 @@
 import { eventSystem } from '../events.js';
 import { detectReferences } from '../references/core/detector.js';
 import { renderReferencesSection } from '../references/ui/display.js';
+import { openCustomReferenceModal } from '../references/ui/custom-reference-modal.js';
 
 /**
  * Initializes Step 4: References
@@ -80,6 +81,20 @@ function handleStep4Entry(state, container) {
     // Render the references section
     if (container) {
         renderReferencesSection(detectionResults.summary, container, totalItems, state);
+
+        // Set up event delegation for "Add custom reference" button
+        container.addEventListener('click', (e) => {
+            const button = e.target.closest('[data-action="add-custom-reference"]');
+            if (button) {
+                openCustomReferenceModal(state, (customRef) => {
+                    // Add the custom reference to state
+                    state.addCustomReference(customRef);
+
+                    // Re-render the references section
+                    handleStep4Entry(state, container);
+                });
+            }
+        });
     }
 
     // Log detection results for debugging

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -79,7 +79,7 @@ function handleStep4Entry(state, container) {
 
     // Render the references section
     if (container) {
-        renderReferencesSection(detectionResults.summary, container, totalItems);
+        renderReferencesSection(detectionResults.summary, container, totalItems, state);
     }
 
     // Log detection results for debugging

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -117,6 +117,11 @@ function handleStep4Entry(state, container) {
                         // Add as new custom reference (converted from auto-detected)
                         state.addCustomReference(customRef);
 
+                        // Hide the original auto-detected reference by toggling it to "ignored"
+                        if (customRef.originalType && state.isReferenceTypeSelected(customRef.originalType)) {
+                            state.toggleReferenceType(customRef.originalType);
+                        }
+
                         // Re-render the references section
                         handleStep4Entry(state, container);
                     }, {
@@ -129,9 +134,9 @@ function handleStep4Entry(state, container) {
                     const existingReference = customReferences.find(ref => ref.id === referenceId);
 
                     if (existingReference) {
-                        openCustomReferenceModal(state, (updatedData) => {
-                            // Update the existing custom reference
-                            state.updateCustomReference(updatedData.id, updatedData);
+                        openCustomReferenceModal(state, (customRef) => {
+                            // Update the existing custom reference with complete data
+                            state.updateCustomReference(customRef.id, customRef);
 
                             // Re-render the references section
                             handleStep4Entry(state, container);

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -72,14 +72,20 @@ function handleStep4Entry(state, container) {
     state.updateState('references.itemReferences', detectionResults.itemReferences, false);
     state.updateState('references.summary', detectionResults.summary, false);
 
+    // Get total number of items
+    const totalItems = Array.isArray(currentState.fetchedData)
+        ? currentState.fetchedData.length
+        : 1;
+
     // Render the references section
     if (container) {
-        renderReferencesSection(detectionResults.summary, container);
+        renderReferencesSection(detectionResults.summary, container, totalItems);
     }
 
     // Log detection results for debugging
     console.log('References detected:', {
         itemCount: Object.keys(detectionResults.itemReferences).length,
+        totalItems: totalItems,
         summary: detectionResults.summary
     });
 }

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -83,8 +83,13 @@ function handleStep4Entry(state, container) {
     if (container) {
         renderReferencesSection(detectionResults.summary, container, totalItems, state);
 
+        // Remove old event listener if it exists to prevent duplication
+        if (container._referenceClickHandler) {
+            container.removeEventListener('click', container._referenceClickHandler);
+        }
+
         // Set up event delegation for reference actions (add and edit)
-        container.addEventListener('click', (e) => {
+        const clickHandler = (e) => {
             // Handle add custom reference button
             const addButton = e.target.closest('[data-action="add-custom-reference"]');
             if (addButton) {
@@ -137,7 +142,11 @@ function handleStep4Entry(state, container) {
                     }
                 }
             }
-        });
+        };
+
+        // Store handler reference and attach listener
+        container._referenceClickHandler = clickHandler;
+        container.addEventListener('click', clickHandler);
     }
 
     // Log detection results for debugging

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -1,0 +1,99 @@
+/**
+ * Step 4: References
+ * Detects and displays reference links from API data
+ *
+ * This step automatically detects three types of references:
+ * - Omeka Item API Links (from top-level @id field)
+ * - OCLC WorldCat Links (from schema:sameAs field)
+ * - ARK Identifiers (from dcterms:identifier field)
+ *
+ * These references are different from identifiers in Step 2 (which are used for reconciliation).
+ * References are complete URLs that will be added to Wikidata statements in the future.
+ *
+ * @module steps/step4
+ */
+
+import { eventSystem } from '../events.js';
+import { detectReferences } from '../references/core/detector.js';
+import { renderReferencesSection } from '../references/ui/display.js';
+
+/**
+ * Initializes Step 4: References
+ * Sets up automatic reference detection and display
+ *
+ * @param {Object} state - Application state management instance
+ */
+export function setupStep4(state) {
+    const proceedToExportBtn = document.getElementById('proceed-to-export');
+    const backToReconciliationBtn = document.getElementById('back-to-reconciliation');
+    const referencesContainer = document.getElementById('references-list');
+
+    // Enable proceed button by default
+    if (proceedToExportBtn) {
+        proceedToExportBtn.disabled = false;
+    }
+
+    // Listen for step changes to detect when entering step 4
+    eventSystem.subscribe(eventSystem.Events.STEP_CHANGED, (data) => {
+        if (data.newStep === 4) {
+            handleStep4Entry(state, referencesContainer);
+        }
+    });
+
+    // Also check if we're already on step 4 (for page refresh scenarios)
+    const currentState = state.getState();
+    if (currentState.currentStep === 4) {
+        handleStep4Entry(state, referencesContainer);
+    }
+}
+
+/**
+ * Handles entry into Step 4
+ * Detects references and updates the display
+ *
+ * @param {Object} state - Application state management instance
+ * @param {HTMLElement} container - Container element for references display
+ */
+function handleStep4Entry(state, container) {
+    const currentState = state.getState();
+
+    // Check if we have fetched data
+    if (!currentState.fetchedData) {
+        if (container) {
+            container.innerHTML = '<p class="placeholder">No data available. Please complete Step 1 first.</p>';
+        }
+        return;
+    }
+
+    // Detect references from the fetched data
+    const detectionResults = detectReferences(currentState.fetchedData);
+
+    // Store results in state
+    state.updateState('references.itemReferences', detectionResults.itemReferences, false);
+    state.updateState('references.summary', detectionResults.summary, false);
+
+    // Render the references section
+    if (container) {
+        renderReferencesSection(detectionResults.summary, container);
+    }
+
+    // Log detection results for debugging
+    console.log('References detected:', {
+        itemCount: Object.keys(detectionResults.itemReferences).length,
+        summary: detectionResults.summary
+    });
+}
+
+/**
+ * Gets the current reference detection results from state
+ *
+ * @param {Object} state - Application state management instance
+ * @returns {Object} Current reference data
+ */
+export function getReferences(state) {
+    const currentState = state.getState();
+    return {
+        itemReferences: currentState.references?.itemReferences || {},
+        summary: currentState.references?.summary || {}
+    };
+}


### PR DESCRIPTION
## Summary
Implements comprehensive custom reference management and editing capabilities for Step 4, allowing users to add and modify reference mappings with complete data integrity and intuitive positioning.

## Features Added
- **Custom Reference Creation**: Add custom references with item-specific URLs via modal interface
- **Reference Editing**: Edit both auto-detected and custom references through unified modal
- **Position Preservation**: Edited auto-detected references replace originals in same position
- **Base URL Display**: Consistent base URL display for all reference types (auto-detected and custom)

## Bug Fixes
- Fixed modal duplication issue (event listener accumulation)
- Fixed pre-fill not working for auto-detected references (itemId key mismatch)
- Fixed incomplete data when editing references
- Fixed reference name pre-filling to use correct "Omeka API item" label

## Changes
- Changed label from "Omeka item" to "Omeka API item"
- Auto-detected references now show base URLs instead of verbose descriptions
- Replaced auto-detected references are completely hidden (not just grayed out)
- Custom replacements appear in original position, not at end of list

## Test Plan
- [x] Add custom reference via "+ Add custom reference" button
- [x] Edit auto-detected reference (Omeka API item, OCLC, ARK)
- [x] Edit custom reference
- [x] Verify replaced references completely disappear
- [x] Verify position preservation when editing
- [x] Verify base URLs display correctly without protocol
- [x] Verify reference name pre-fills correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)