### PR TITLE
Step 3 Stability Improvements and UX Enhancements

### DIFF
--- a/src/js/reconciliation/ui/modals/external-id-modal.js
+++ b/src/js/reconciliation/ui/modals/external-id-modal.js
@@ -32,7 +32,6 @@ function getConfirmedValue(itemId, property, valueIndex) {
         // Try multiple ways to access the state system
         const stateManager = window.debugState || window.currentState;
         if (!stateManager) {
-            console.warn('No state system available');
             return null;
         }
         
@@ -60,7 +59,6 @@ function getConfirmedValue(itemId, property, valueIndex) {
         
         return null;
     } catch (error) {
-        console.warn('Failed to retrieve confirmed value from state:', error);
         return null;
     }
 }
@@ -77,7 +75,6 @@ function saveConfirmedValue(itemId, property, valueIndex, confirmationData) {
         // Try multiple ways to access the state system
         const stateManager = window.debugState || window.currentState;
         if (!stateManager) {
-            console.warn('No state system available');
             return false;
         }
         
@@ -114,7 +111,6 @@ function saveConfirmedValue(itemId, property, valueIndex, confirmationData) {
         
         return true;
     } catch (error) {
-        console.warn('Failed to save confirmed value to state:', error);
         return false;
     }
 }
@@ -147,7 +143,6 @@ function findSourceTableCell(itemId, property, valueIndex) {
         const fallbackCell = document.querySelector(fallbackSelector);
         return fallbackCell;
     } catch (error) {
-        console.warn('Failed to find source table cell:', error, { itemId, property, valueIndex });
         return null;
     }
 }
@@ -159,7 +154,6 @@ function findSourceTableCell(itemId, property, valueIndex) {
  */
 function updateSourceTableCell(sourceCell, confirmationData) {
     if (!sourceCell) {
-        console.warn('No source cell found to update');
         return;
     }
     
@@ -170,7 +164,6 @@ function updateSourceTableCell(sourceCell, confirmationData) {
         const propertyValueDiv = sourceCell.querySelector('.property-value');
         
         if (!valueTextSpan) {
-            console.warn('Could not find .value-text span in source cell');
             return;
         }
         
@@ -195,7 +188,6 @@ function updateSourceTableCell(sourceCell, confirmationData) {
         sourceCell.classList.add('reconciled');
         
     } catch (error) {
-        console.error('Failed to update source table cell:', error);
     }
 }
 
@@ -216,32 +208,9 @@ export function createExternalIdModal(itemId, property, valueIndex, value, prope
     const hasConfirmedValue = confirmedData !== null;
     
     // Add comprehensive debugging for constraint extraction
-    console.log('🔍 [External-ID Modal] Creating modal for:', {
-        itemId,
-        property,
-        valueIndex,
-        value,
-        displayValue,
-        hasPropertyData: !!propertyData,
-        propertyDataStructure: propertyData ? Object.keys(propertyData) : null
-    });
-    
     const regexConstraints = extractRegexConstraints(property, propertyData);
-    console.log('📋 [External-ID Modal] Extracted constraints:', {
-        hasConstraints: !!regexConstraints,
-        constraints: regexConstraints,
-        property,
-        propertyDataConstraints: propertyData?.constraints
-    });
-    
     // Only validate if we have constraints
     const validationResult = regexConstraints ? validateStringValue(displayValue, regexConstraints) : null;
-    console.log('✅ [External-ID Modal] Validation result:', {
-        hasValidationResult: !!validationResult,
-        validationResult,
-        willShowValidation: !!regexConstraints
-    });
-    
     const propertyLink = generatePropertyLink(property, propertyData);
     
     const modalContent = document.createElement('div');
@@ -338,14 +307,6 @@ export function createExternalIdModal(itemId, property, valueIndex, value, prope
  * @param {HTMLElement} modalElement - The modal element
  */
 export function initializeExternalIdModal(modalElement) {
-    console.log('🚀 [EXTERNAL-ID MODAL] === initializeExternalIdModal CALLED ===');
-    console.log('🚀 [EXTERNAL-ID MODAL] Modal element:', {
-        element: modalElement,
-        className: modalElement?.className,
-        id: modalElement?.id,
-        hasElement: !!modalElement
-    });
-    
     const originalValue = modalElement.dataset.originalValue;
     const currentValue = modalElement.dataset.currentValue;
     const property = modalElement.dataset.property;
@@ -354,25 +315,8 @@ export function initializeExternalIdModal(modalElement) {
         JSON.parse(modalElement.dataset.propertyData) : null;
     const confirmedData = modalElement.dataset.confirmedData ? 
         JSON.parse(modalElement.dataset.confirmedData) : null;
-    
-    console.log('🚀 [EXTERNAL-ID MODAL] Extracted data from modal element:', {
-        originalValue,
-        currentValue,
-        property,
-        hasConfirmedValue,
-        hasPropertyData: !!propertyData,
-        hasConfirmedData: !!confirmedData,
-        itemId: modalElement.dataset.itemId,
-        valueIndex: modalElement.dataset.valueIndex
-    });
-    
     // Find the source table cell that opened this modal
     const sourceCell = findSourceTableCell(modalElement.dataset.itemId, property, parseInt(modalElement.dataset.valueIndex));
-    console.log('🚀 [EXTERNAL-ID MODAL] Source cell search result:', {
-        found: !!sourceCell,
-        sourceCell
-    });
-    
     // Store modal context globally for interaction handlers
     window.currentModalContext = {
         itemId: modalElement.dataset.itemId,
@@ -388,32 +332,15 @@ export function initializeExternalIdModal(modalElement) {
         confirmedData: confirmedData,
         sourceCell: sourceCell // Reference to the original table cell
     };
-    
-    console.log('🚀 [EXTERNAL-ID MODAL] Set up window.currentModalContext:', window.currentModalContext);
-    
     // Set up external-id input with enhanced functionality
-    console.log('🚀 [EXTERNAL-ID MODAL] Looking for external-id-input element...');
     const externalIdInput = document.getElementById('external-id-input');
-    console.log('🚀 [EXTERNAL-ID MODAL] External-id input search result:', {
-        found: !!externalIdInput,
-        element: externalIdInput,
-        id: externalIdInput?.id,
-        className: externalIdInput?.className,
-        value: externalIdInput?.value
-    });
-    
     if (externalIdInput) {
-        console.log('✅ [EXTERNAL-ID MODAL] About to call setupExternalIdInput...');
         setupExternalIdInput(externalIdInput, property, propertyData);
-        console.log('✅ [EXTERNAL-ID MODAL] setupExternalIdInput completed');
     } else {
-        console.error('❌ [EXTERNAL-ID MODAL] No external-id-input element found!');
     }
     
     // Initial validation and UI state
-    console.log('🚀 [EXTERNAL-ID MODAL] About to call initial updateValidationState...');
     updateValidationState();
-    console.log('✅ [EXTERNAL-ID MODAL] === initializeExternalIdModal FINISHED ===');
 }
 
 /**
@@ -436,14 +363,6 @@ function escapeHtml(text) {
  */
 function setupExternalIdInput(input, property, propertyData) {
     let isFirstEdit = true;
-    
-    console.log('🚀 [SETUP] Setting up external-id input:', {
-        inputId: input.id,
-        property,
-        hasPropertyData: !!propertyData,
-        propertyData
-    });
-    
     // Clear any previous validation timeout
     if (window.validationTimeout) {
         clearTimeout(window.validationTimeout);
@@ -452,14 +371,6 @@ function setupExternalIdInput(input, property, propertyData) {
     // Set up input event for original value display and validation
     input.addEventListener('input', function(e) {
         const currentValue = input.value;
-        console.log('⌨️ [KEYSTROKE] INPUT event fired:', {
-            eventType: 'input',
-            currentValue: `"${currentValue}"`,
-            valueLength: currentValue.length,
-            property,
-            timestamp: new Date().toISOString()
-        });
-        
         // Show original value hint on first edit
         if (isFirstEdit && currentValue !== window.currentModalContext.originalValue) {
             showOriginalValueHint();
@@ -471,60 +382,31 @@ function setupExternalIdInput(input, property, propertyData) {
         window.currentModalContext.currentValue = currentValue;
         
         // Update validation immediately - no debouncing for input events
-        console.log('🔄 [KEYSTROKE] About to call updateValidationState from input event');
         updateValidationState();
     });
     
     // Set up keyup for additional feedback
     input.addEventListener('keyup', function(e) {
         const currentValue = input.value;
-        console.log('⌨️ [KEYSTROKE] KEYUP event fired:', {
-            eventType: 'keyup',
-            key: e.key,
-            keyCode: e.keyCode,
-            currentValue: `"${currentValue}"`,
-            valueLength: currentValue.length,
-            property,
-            timestamp: new Date().toISOString()
-        });
-        
         window.currentModalContext.currentValue = currentValue;
-        console.log('🔄 [KEYSTROKE] About to call updateValidationState from keyup event');
         updateValidationState();
     });
     
     // Set up blur event for final validation
     input.addEventListener('blur', function() {
         const currentValue = input.value;
-        console.log('⌨️ [KEYSTROKE] BLUR event fired:', {
-            eventType: 'blur',
-            currentValue: `"${currentValue}"`,
-            valueLength: currentValue.length,
-            property,
-            timestamp: new Date().toISOString()
-        });
         updateValidationState();
     });
     
     // Set up paste event for validation after paste
     input.addEventListener('paste', function() {
-        console.log('⌨️ [KEYSTROKE] PASTE event fired');
         // Small delay to let paste complete
         setTimeout(() => {
             const currentValue = input.value;
-            console.log('⌨️ [KEYSTROKE] PASTE completed:', {
-                eventType: 'paste',
-                currentValue: `"${currentValue}"`,
-                valueLength: currentValue.length,
-                property,
-                timestamp: new Date().toISOString()
-            });
             window.currentModalContext.currentValue = currentValue;
             updateValidationState();
         }, 10);
     });
-    
-    console.log('✅ [SETUP] All event listeners attached for external-id input');
 }
 
 /**
@@ -541,11 +423,8 @@ function showOriginalValueHint() {
  * Update validation state and visual feedback
  */
 function updateValidationState() {
-    console.log('🎯 [VALIDATION] === updateValidationState CALLED ===');
-    
     const input = document.getElementById('external-id-input');
     if (!input) {
-        console.error('❌ [VALIDATION] No input element found with id "external-id-input"');
         return;
     }
     
@@ -554,69 +433,29 @@ function updateValidationState() {
     const property = window.currentModalContext?.property;
     const propertyData = window.currentModalContext?.propertyData;
     const feedbackContainer = document.getElementById('validation-feedback');
-    
-    console.log('📊 [VALIDATION] Initial state:', {
-        currentValue: `"${currentValue}"`,
-        valueLength: currentValue.length,
-        property,
-        hasPropertyData: !!propertyData,
-        modalContext: window.currentModalContext ? 'exists' : 'missing',
-        feedbackContainer: feedbackContainer ? 'exists' : 'missing'
-    });
-    
     // Update context with current value from input
     if (window.currentModalContext) {
         window.currentModalContext.currentValue = currentValue;
     }
     
     if (!property) {
-        console.error('❌ [VALIDATION] No property available - cannot validate');
         return;
     }
     
     // Get constraints with debugging
-    console.log('🔍 [VALIDATION] About to extract regex constraints...');
     const constraints = extractRegexConstraints(property, propertyData);
-    console.log('📋 [VALIDATION] Constraints extraction result:', {
-        hasConstraints: !!constraints,
-        constraints,
-        constraintPattern: constraints?.pattern,
-        constraintSource: constraints?.source,
-        propertyDataStructure: propertyData ? Object.keys(propertyData) : null,
-        propertyDataConstraints: propertyData?.constraints
-    });
-    
     // Clear all validation classes first - preserve other classes
     const classesBefore = input.className;
     input.classList.remove('validation-success', 'validation-error', 'validation-warning');
-    console.log('🧹 [VALIDATION] Cleared validation classes:', {
-        classesBefore,
-        classesAfter: input.className
-    });
-    
     // Only validate if we have constraints
     let validationResult = null;
     if (constraints) {
-        console.log('⚖️ [VALIDATION] About to call validateRealTime with:', {
-            currentValue: `"${currentValue}"`,
-            constraintPattern: constraints.pattern,
-            constraintDescription: constraints.description
-        });
         validationResult = validateRealTime(currentValue, constraints);
-        console.log('📝 [VALIDATION] validateRealTime returned:', {
-            validationResult,
-            isValid: validationResult?.isValid,
-            level: validationResult?.level,
-            message: validationResult?.message
-        });
     } else {
-        console.log('⚠️ [VALIDATION] No constraints found - skipping validation');
     }
     
     // Only apply validation styling if we have constraints AND a validation result
     if (constraints && validationResult) {
-        console.log('🎨 [VALIDATION] Applying validation styling based on result...');
-        
         let classToAdd = '';
         if (validationResult.isValid === true) {
             classToAdd = 'validation-success';
@@ -628,21 +467,7 @@ function updateValidationState() {
             classToAdd = 'validation-error';
             input.classList.add('validation-error');
         }
-        
-        console.log('✅ [VALIDATION] Applied validation class:', {
-            classAdded: classToAdd,
-            isValid: validationResult.isValid,
-            level: validationResult.level,
-            finalClasses: input.className,
-            computedStyle: window.getComputedStyle(input).borderColor
-        });
     } else {
-        console.log('⚪ [VALIDATION] No validation styling applied:', {
-            hasConstraints: !!constraints,
-            hasValidationResult: !!validationResult,
-            reason: !constraints ? 'No regex constraints available' : 'No validation result',
-            finalClasses: input.className
-        });
     }
     
     // Update validation feedback only if we have constraints and validation result
@@ -656,22 +481,14 @@ function updateValidationState() {
                 </div>
             `;
             feedbackContainer.innerHTML = feedbackHTML;
-            console.log('💬 [VALIDATION] Updated feedback container:', {
-                message: validationResult.message,
-                icon,
-                level: validationResult.level
-            });
         } else {
             // Clear feedback if no constraints or no validation result
             feedbackContainer.innerHTML = '';
-            console.log('🧹 [VALIDATION] Cleared feedback container');
         }
     }
     
     // Update confirm button state
     updateConfirmButtonState();
-    
-    console.log('🏁 [VALIDATION] === updateValidationState FINISHED ===');
 }
 
 /**
@@ -757,7 +574,6 @@ window.resetExternalIdModal = function() {
 
 window.confirmExternalIdValue = function() {
     if (!window.currentModalContext) {
-        console.error('No modal context available for external-id confirmation');
         return;
     }
     
@@ -780,41 +596,21 @@ window.confirmExternalIdValue = function() {
     const property = window.currentModalContext.property;
     const propertyData = window.currentModalContext.propertyData;
     const constraints = extractRegexConstraints(property, propertyData);
-    
-    console.log('🔒 [External-ID Modal] Confirmation validation check:', {
-        property,
-        currentValue,
-        hasConstraints: !!constraints,
-        constraints,
-        willValidate: !!constraints
-    });
-    
     if (constraints) {
         const validationResult = validateStringValue(currentValue, constraints);
-        console.log('⚖️ [External-ID Modal] Validation before confirmation:', {
-            isValid: validationResult.isValid,
-            message: validationResult.message,
-            pattern: constraints.pattern
-        });
-        
         if (!validationResult.isValid) {
-            console.log('⚠️ [External-ID Modal] Showing override dialog for invalid value');
             const confirmOverride = confirm(
                 `Warning: The value "${currentValue}" does not match the required format.\n\n` +
                 `Expected pattern: ${constraints.pattern}\n\n` +
                 `Do you want to use this value anyway?`
             );
             if (!confirmOverride) {
-                console.log('❌ [External-ID Modal] User cancelled override - not confirming value');
                 return;
             } else {
-                console.log('✅ [External-ID Modal] User approved override - proceeding with invalid value');
             }
         } else {
-            console.log('✅ [External-ID Modal] Value passes validation - proceeding');
         }
     } else {
-        console.log('ℹ️ [External-ID Modal] No constraints available - skipping validation check');
     }
     
     // Prepare confirmation data
@@ -894,6 +690,5 @@ window.confirmExternalIdValue = function() {
             }, 1000);
         }
     } else {
-        console.warn('No save handler found - value may not be persisted');
     }
 };

--- a/src/js/reconciliation/ui/modals/modal-factory.js
+++ b/src/js/reconciliation/ui/modals/modal-factory.js
@@ -79,18 +79,11 @@ const modalRegistry = {
  * @throws {Error} If data type is not supported
  */
 export function createReconciliationModalByType(dataType, itemId, property, valueIndex, value, propertyData = null, existingMatches = null) {
-    console.log('🏭 createReconciliationModalByType called with dataType:', dataType);
-    console.log('🏭 Available modal types:', Object.keys(modalRegistry));
-    
     const modalHandler = modalRegistry[dataType];
     
     if (!modalHandler) {
-        console.error('❌ Unsupported modal type:', dataType);
         throw new Error(`Unsupported reconciliation modal type: ${dataType}. Supported types: ${Object.keys(modalRegistry).join(', ')}`);
     }
-    
-    console.log('✅ Found modal handler for type:', dataType, 'Handler name:', modalHandler.name);
-    
     try {
         const modalElement = modalHandler.create(itemId, property, valueIndex, value, propertyData, existingMatches);
         
@@ -101,7 +94,6 @@ export function createReconciliationModalByType(dataType, itemId, property, valu
         
         return modalElement;
     } catch (error) {
-        console.error(`Error creating ${modalHandler.name}:`, error);
         throw new Error(`Failed to create reconciliation modal for type ${dataType}: ${error.message}`);
     }
 }
@@ -120,31 +112,13 @@ export function initializeReconciliationModal(modalElement) {
     if (!dataType) {
         throw new Error('Modal element missing data-type attribute');
     }
-    
-    console.log('🏭 [MODAL FACTORY] Data type found:', dataType);
-    console.log('🏭 [MODAL FACTORY] Available modal types:', Object.keys(modalRegistry));
-    
     const modalHandler = modalRegistry[dataType];
     if (!modalHandler) {
-        console.error('❌ [MODAL FACTORY] No modal handler found for data type:', dataType);
         throw new Error(`No modal handler found for data type: ${dataType}`);
     }
-    
-    console.log('✅ [MODAL FACTORY] Modal handler found:', {
-        dataType,
-        handlerName: modalHandler.name,
-        hasInitialize: typeof modalHandler.initialize === 'function'
-    });
-    
     try {
         modalHandler.initialize(modalElement);
     } catch (error) {
-        console.error(`❌ [MODAL FACTORY] Error initializing ${modalHandler.name}:`, {
-            error: error.message,
-            stack: error.stack,
-            dataType,
-            modalElement
-        });
         throw new Error(`Failed to initialize reconciliation modal for type ${dataType}: ${error.message}`);
     }
 }
@@ -193,7 +167,6 @@ export function getModalTypeInfo(dataType) {
  */
 export function registerModalType(dataType, createFunction, initializeFunction, name) {
     if (modalRegistry[dataType]) {
-        console.warn(`Modal type ${dataType} is already registered. Overwriting.`);
     }
     
     modalRegistry[dataType] = {

--- a/src/js/reconciliation/ui/validation-engine.js
+++ b/src/js/reconciliation/ui/validation-engine.js
@@ -88,44 +88,12 @@ const CONSTRAINT_DATABASE = {
  * @returns {Object|null} Constraint object or null if no constraints
  */
 export function extractRegexConstraints(property, propertyData = null) {
-    console.log('🔍 [CONSTRAINT EXTRACTION] === extractRegexConstraints CALLED ===');
-    console.log('🔍 [CONSTRAINT EXTRACTION] Input parameters:', {
-        property: `"${property}"`,
-        hasPropertyData: !!propertyData,
-        propertyDataType: typeof propertyData,
-        propertyDataStructure: propertyData ? Object.keys(propertyData) : null,
-        fullPropertyData: propertyData
-    });
-    
     // First check if we have explicit constraint data from Wikidata
     if (propertyData && propertyData.constraints) {
-        console.log('📋 [CONSTRAINT EXTRACTION] Found propertyData.constraints - analyzing structure...');
-        console.log('📋 [CONSTRAINT EXTRACTION] Constraints structure:', {
-            constraintsType: typeof propertyData.constraints,
-            constraintsKeys: propertyData.constraints ? Object.keys(propertyData.constraints) : null,
-            hasFormat: !!propertyData.constraints.format,
-            formatType: typeof propertyData.constraints.format,
-            formatIsArray: Array.isArray(propertyData.constraints.format),
-            formatLength: propertyData.constraints.format?.length || 0,
-            fullConstraints: propertyData.constraints
-        });
-        
         // Check for format constraints array (new structure)
         if (propertyData.constraints.format && Array.isArray(propertyData.constraints.format)) {
-            console.log('📝 [CONSTRAINT EXTRACTION] Processing format constraints array with', propertyData.constraints.format.length, 'items...');
-            
             for (let i = 0; i < propertyData.constraints.format.length; i++) {
                 const formatConstraint = propertyData.constraints.format[i];
-                console.log(`🔎 [CONSTRAINT EXTRACTION] Examining format constraint [${i}]:`, {
-                    constraintType: typeof formatConstraint,
-                    constraintKeys: formatConstraint ? Object.keys(formatConstraint) : null,
-                    hasRegex: !!formatConstraint.regex,
-                    regexValue: formatConstraint.regex,
-                    hasPattern: !!formatConstraint.pattern,
-                    patternValue: formatConstraint.pattern,
-                    fullConstraint: formatConstraint
-                });
-                
                 // Look for regex field (new structure)
                 if (formatConstraint.regex) {
                     const result = {
@@ -134,7 +102,6 @@ export function extractRegexConstraints(property, propertyData = null) {
                         source: 'wikidata',
                         rank: formatConstraint.rank
                     };
-                    console.log('✅ [CONSTRAINT EXTRACTION] FOUND constraint via regex field:', result);
                     return result;
                 }
                 
@@ -146,30 +113,15 @@ export function extractRegexConstraints(property, propertyData = null) {
                         source: 'wikidata',
                         rank: formatConstraint.rank
                     };
-                    console.log('✅ [CONSTRAINT EXTRACTION] FOUND constraint via pattern field:', result);
                     return result;
                 }
             }
-            console.log('❌ [CONSTRAINT EXTRACTION] No regex/pattern found in any format constraint');
         } else {
-            console.log('⚠️ [CONSTRAINT EXTRACTION] propertyData.constraints.format is not a valid array:', {
-                format: propertyData.constraints.format,
-                formatType: typeof propertyData.constraints.format,
-                formatIsArray: Array.isArray(propertyData.constraints.format)
-            });
         }
         
         // Legacy check: constraints as direct array (old structure)
         if (Array.isArray(propertyData.constraints)) {
-            console.log('📝 [Validation Engine] Checking legacy constraints array:');
             for (const constraint of propertyData.constraints) {
-                console.log('🔎 [Validation Engine] Examining legacy constraint:', {
-                    type: constraint.type,
-                    hasPattern: !!constraint.pattern,
-                    hasRegex: !!constraint.regex,
-                    constraint
-                });
-                
                 if (constraint.type === 'format') {
                     if (constraint.regex) {
                         const result = {
@@ -177,7 +129,6 @@ export function extractRegexConstraints(property, propertyData = null) {
                             description: constraint.description || `Must match pattern: ${constraint.regex}`,
                             source: 'wikidata'
                         };
-                        console.log('✅ [Validation Engine] Found legacy format constraint (regex field):', result);
                         return result;
                     }
                     
@@ -187,32 +138,22 @@ export function extractRegexConstraints(property, propertyData = null) {
                             description: constraint.description || `Must match pattern: ${constraint.pattern}`,
                             source: 'wikidata'
                         };
-                        console.log('✅ [Validation Engine] Found legacy format constraint (pattern field):', result);
                         return result;
                     }
                 }
             }
         }
-        
-        console.log('❌ [Validation Engine] No format constraints found in Wikidata data');
     } else {
-        console.log('❌ [Validation Engine] No propertyData or constraints available');
     }
     
     // Fallback to local constraint database
     const lowerProperty = property.toLowerCase();
-    console.log('🗂️ [Validation Engine] Checking local constraint database:', {
-        lowerProperty,
-        availableKeys: Object.keys(CONSTRAINT_DATABASE)
-    });
-    
     // Direct match first
     if (CONSTRAINT_DATABASE[lowerProperty]) {
         const result = {
             ...CONSTRAINT_DATABASE[lowerProperty],
             source: 'builtin'
         };
-        console.log('✅ [Validation Engine] Found direct match in local database:', result);
         return result;
     }
     
@@ -223,15 +164,9 @@ export function extractRegexConstraints(property, propertyData = null) {
                 ...constraint,
                 source: 'builtin'
             };
-            console.log('✅ [Validation Engine] Found pattern match in local database:', {
-                matchedKey: key,
-                result
-            });
             return result;
         }
     }
-    
-    console.log('❌ [Validation Engine] No constraints found anywhere for property:', property);
     return null;
 }
 
@@ -242,65 +177,29 @@ export function extractRegexConstraints(property, propertyData = null) {
  * @returns {Object} Validation result
  */
 export function validateStringValue(value, constraints) {
-    console.log('🧪 [STRING VALIDATION] === validateStringValue CALLED ===');
-    console.log('🧪 [STRING VALIDATION] Input parameters:', {
-        value: `"${value}"`,
-        valueType: typeof value,
-        valueTrimmed: value ? `"${value.trim()}"` : null,
-        hasConstraints: !!constraints,
-        constraintPattern: constraints?.pattern,
-        constraintErrorMessage: constraints?.errorMessage,
-        fullConstraints: constraints
-    });
-    
     if (!constraints || !constraints.pattern) {
-        console.log('⚠️ [STRING VALIDATION] No constraints or pattern - returning neutral');
         const result = {
             isValid: true,
             message: 'No validation constraints defined',
             level: 'info'
         };
-        console.log('🧪 [STRING VALIDATION] Returning:', result);
         return result;
     }
     
     if (!value || value.trim() === '') {
-        console.log('📭 [STRING VALIDATION] Empty value - returning error');
         const result = {
             isValid: false,
             message: 'Value cannot be empty',
             level: 'error'
         };
-        console.log('🧪 [STRING VALIDATION] Returning:', result);
         return result;
     }
     
     try {
         const pattern = constraints.pattern;
         const trimmedValue = value.trim();
-        
-        console.log('🔍 [STRING VALIDATION] About to test regex:', {
-            pattern: `"${pattern}"`,
-            trimmedValue: `"${trimmedValue}"`,
-            patternType: typeof pattern
-        });
-        
         const regex = new RegExp(pattern);
-        console.log('✅ [STRING VALIDATION] Regex object created successfully:', {
-            regexSource: regex.source,
-            regexFlags: regex.flags,
-            regexString: regex.toString()
-        });
-        
         const isValid = regex.test(trimmedValue);
-        console.log('🎯 [STRING VALIDATION] Regex test completed:', {
-            isValid,
-            pattern: `"${pattern}"`,
-            trimmedValue: `"${trimmedValue}"`,
-            regexTest: `/${pattern}/.test("${trimmedValue}")`,
-            result: isValid
-        });
-        
         const result = {
             isValid,
             message: isValid ? 'Value is valid' : (constraints.errorMessage || `Value does not match required pattern`),
@@ -309,23 +208,14 @@ export function validateStringValue(value, constraints) {
             description: constraints.description,
             examples: constraints.examples
         };
-        
-        console.log('🧪 [STRING VALIDATION] Final result:', result);
-        console.log('🧪 [STRING VALIDATION] === validateStringValue FINISHED ===');
         return result;
         
     } catch (error) {
-        console.error('❌ [STRING VALIDATION] Invalid regex pattern:', {
-            pattern: constraints.pattern,
-            error: error.message,
-            errorStack: error.stack
-        });
         const result = {
             isValid: true,
             message: 'Constraint pattern is invalid - validation skipped',
             level: 'warning'
         };
-        console.log('🧪 [STRING VALIDATION] Returning error result:', result);
         return result;
     }
 }
@@ -337,64 +227,32 @@ export function validateStringValue(value, constraints) {
  * @returns {Object} Real-time validation result
  */
 export function validateRealTime(value, constraints) {
-    console.log('⚖️ [REAL-TIME VALIDATION] === validateRealTime CALLED ===');
-    console.log('⚖️ [REAL-TIME VALIDATION] Input parameters:', {
-        value: `"${value}"`,
-        valueType: typeof value,
-        valueLength: value ? value.length : 0,
-        hasConstraints: !!constraints,
-        constraintsType: typeof constraints,
-        constraintPattern: constraints?.pattern,
-        fullConstraints: constraints
-    });
-    
     if (!constraints || !constraints.pattern) {
-        console.log('⚠️ [REAL-TIME VALIDATION] No constraints or pattern available - returning neutral result');
         const result = {
             isValid: true,
             message: '',
             showHint: false
         };
-        console.log('⚖️ [REAL-TIME VALIDATION] Returning:', result);
         return result;
     }
     
     // Empty value - show hint
     if (!value || value.trim() === '') {
-        console.log('📭 [REAL-TIME VALIDATION] Empty value detected - returning hint');
         const result = {
             isValid: false,
             message: constraints.description || 'Enter a value',
             showHint: true,
             level: 'info'
         };
-        console.log('⚖️ [REAL-TIME VALIDATION] Returning:', result);
         return result;
     }
-    
-    console.log('🧪 [REAL-TIME VALIDATION] About to call validateStringValue...');
     // Validate current value
     const result = validateStringValue(value, constraints);
-    console.log('📋 [REAL-TIME VALIDATION] validateStringValue returned:', {
-        result,
-        isValid: result?.isValid,
-        message: result?.message,
-        level: result?.level
-    });
-    
     // For invalid values, provide helpful hints
     if (!result.isValid && constraints.examples) {
         const originalMessage = result.message;
         result.message += `. Examples: ${constraints.examples.slice(0, 2).join(', ')}`;
-        console.log('💡 [REAL-TIME VALIDATION] Added examples to message:', {
-            originalMessage,
-            newMessage: result.message,
-            examples: constraints.examples.slice(0, 2)
-        });
     }
-    
-    console.log('⚖️ [REAL-TIME VALIDATION] Final result:', result);
-    console.log('⚖️ [REAL-TIME VALIDATION] === validateRealTime FINISHED ===');
     return result;
 }
 
@@ -587,18 +445,12 @@ export function validateBatch(values) {
  * @returns {Promise<Array>} Array of language objects with enhanced data
  */
 export async function searchWikidataLanguages(query) {
-    console.log('🔍 searchWikidataLanguages called with query:', query);
-    
     const queryTrimmed = query.trim();
     
     // Fast fallback results for immediate response
-    console.log('🔍 Getting fallback results for:', queryTrimmed);
     const fallbackResults = searchFallbackLanguages(queryTrimmed);
-    console.log('🔍 Fallback results:', fallbackResults);
-    
     // For very short queries, just return fallback
     if (queryTrimmed.length < 2) {
-        console.log('🔍 Query too short, returning fallback only');
         return fallbackResults;
     }
     
@@ -619,7 +471,6 @@ export async function searchWikidataLanguages(query) {
         return combinedResults.slice(0, 12); // Limit total results
         
     } catch (error) {
-        console.warn('Wikidata language search failed:', error);
         return fallbackResults;
     }
 }
@@ -792,25 +643,18 @@ function combineLanguageResults(wikidataResults, fallbackResults) {
  * @returns {Array} Array of matching languages
  */
 function searchFallbackLanguages(query) {
-    console.log('🔍 searchFallbackLanguages called with:', query);
-    
     const queryLower = query.toLowerCase().trim();
     
     if (!queryLower) {
-        console.log('🔍 Empty query, returning empty array');
         return [];
     }
     
     const commonLanguages = getCommonLanguages();
-    console.log('🔍 Common languages available:', commonLanguages.length);
-    
     const results = commonLanguages.filter(lang => 
         lang.label.toLowerCase().includes(queryLower) ||
         lang.code.toLowerCase().includes(queryLower) ||
         lang.code.toLowerCase().startsWith(queryLower)
     ).slice(0, 12);
-    
-    console.log('🔍 Fallback search results for "' + query + '":', results);
     return results;
 }
 
@@ -936,7 +780,6 @@ export function getStoredLanguage() {
         const stored = localStorage.getItem('reconciliation_last_language');
         return stored ? JSON.parse(stored) : null;
     } catch (error) {
-        console.error('Error reading stored language:', error);
         return null;
     }
 }
@@ -949,7 +792,6 @@ export function setStoredLanguage(language) {
     try {
         localStorage.setItem('reconciliation_last_language', JSON.stringify(language));
     } catch (error) {
-        console.error('Error storing language preference:', error);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR consolidates multiple improvements to Step 3 (Reconciliation) workflow, Step 2 (Mapping) UX enhancements, and Step 4 refactoring. Key improvements include item linking to existing Wikidata items, enhanced mapping workflow, and modal interaction fixes.

## Key Features

### Item-Level Reconciliation (#121)
- **Link items to existing Wikidata items**: Instead of always creating new items, users can now link to existing Wikidata items
- Items display as "new item N" with inline link button (🔗)
- Search modal with keystroke-based debounced search (300ms)
- Linked items generate UPDATE statements instead of CREATE in export
- New state management: `linkedItems` with `linkItemToWikidata()`, `unlinkItem()`, `getLinkedItem()` methods

### Step 2 Mapping Workflow Improvements (#122)
- **Quick-add buttons** for common properties: Label, Description, Aliases, Instance of
- **Required property placeholders**: Red placeholders appear in Mapped Keys for Label and Instance of when missing
- Clicking placeholders opens modal with property pre-selected
- Custom mappings show frequency as (N/N) for all items
- Repositioned and restyled "Add Wikidata Property" button

### Modal UX Improvements
- **Keystroke-based search** with 300ms debounce across all Wikidata search modals
- Removed manual search buttons in favor of instant search
- Consistent result format: "Label (QID)" with descriptions below
- Hover styles for clickable results (light gray background, pointer cursor)
- Fixed modal closing behavior (globallyexposed modalUI.closeModal)

### Step 4 Refactoring (#120)
- Emptied Step 4 content and renamed from "Wikidata Designer" to "References"
- Reduced designer.js from ~4100 lines to 26 lines (placeholder)
- Removed ~900 lines of designer-specific CSS
- Updated documentation and tests

### Bug Fixes
- Fixed monolingual text modal language selection dropdown (#119)
- Removed excessive console.log statements
- Fixed event delegation issues in language selection

## Testing
- ✅ Link items to existing Wikidata items and verify UPDATE statements in export
- ✅ Test quick-add buttons for Label, Description, Aliases, Instance of
- ✅ Verify required property placeholders appear and disappear correctly
- ✅ Test keystroke-based search in all modals
- ✅ Verify modal closing behavior
- ✅ Verify language selection in monolingual text modal

## Documentation
- Updated JS_MODULE_MAP.md with new modules and exports
- Updated README.md and CLAUDE.md for Step 4 changes
- Added JSDoc comments for new functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>