### PR TITLE
Value transformation improvements and reconciliation enhancements

### DIFF
--- a/src/js/mapping/core/property-searcher.js
+++ b/src/js/mapping/core/property-searcher.js
@@ -663,7 +663,30 @@ export async function selectProperty(property, state) {
     
     // Store selected property
     window.currentMappingSelectedProperty = property;
-    
+
+    // Transfer transformations from temporary mapping ID to final mapping ID
+    const keyData = window.currentMappingKeyData;
+    if (keyData && keyData.key && state) {
+        const tempMappingId = `temp_${keyData.key}`;
+        const finalMappingId = state.generateMappingId(keyData.key, property.id, keyData.selectedAtField);
+
+        // Check if there are transformations stored under the temporary ID
+        const currentState = state.getState();
+        const tempBlocks = currentState.mappings?.transformationBlocks?.[tempMappingId] || [];
+
+        if (tempBlocks.length > 0) {
+            // Transfer all transformation blocks from temporary to final mapping ID
+            tempBlocks.forEach(block => {
+                state.addTransformationBlock(finalMappingId, block);
+            });
+
+            // Clean up the temporary mapping ID
+            if (currentState.mappings?.transformationBlocks) {
+                delete currentState.mappings.transformationBlocks[tempMappingId];
+            }
+        }
+    }
+
     // Update search input with selected property label
     const searchInput = document.getElementById('property-search-input');
     if (searchInput) {

--- a/src/js/mapping/core/transformation-engine.js
+++ b/src/js/mapping/core/transformation-engine.js
@@ -29,20 +29,20 @@ export function renderValueTransformationUI(keyData, state) {
         id: 'value-transformation-section'
     });
 
-    // Property ID for transformation blocks - simple approach that works
+    // Property ID for transformation blocks - allow temporary IDs when no property selected
     let currentProperty = window.currentMappingSelectedProperty || keyData?.property;
     let propertyId = currentProperty?.id;
-    
-    // Simple validation (no complex retry logic)
-    if (!propertyId) {
-        container.appendChild(createElement('div', {
-            className: 'transformation-message'
-        }, 'Select a property first to configure value transformations'));
-        return container;
+
+    // Generate mapping-specific ID for transformation storage
+    // Use temporary ID when no property selected (same pattern as custom properties)
+    let mappingId;
+    if (propertyId) {
+        // Final mapping ID with property, including @ field if selected
+        mappingId = state.generateMappingId(keyData.key, propertyId, keyData.selectedAtField);
+    } else {
+        // Temporary mapping ID when no property selected yet
+        mappingId = `temp_${keyData.key}`;
     }
-    
-    // Generate mapping-specific ID for transformation storage, including @ field if selected
-    const mappingId = state.generateMappingId(keyData.key, propertyId, keyData.selectedAtField);
 
     // Field selector section
     let rawSampleValue = keyData.sampleValue;

--- a/src/js/mapping/ui/modals/mapping-modal.js
+++ b/src/js/mapping/ui/modals/mapping-modal.js
@@ -658,10 +658,14 @@ export function createMappingModalContent(keyData) {
                 defaultField = fieldGroups[0].fields[0];
             }
             
-            // Store the default selection
-            if (defaultField) {
+            // Store the default selection, but preserve existing selection if already set
+            // This is critical for auto-mapped identifiers to maintain consistent mappingId
+            if (defaultField && !keyData.selectedAtField) {
                 keyData.selectedAtField = defaultField.key;
             }
+
+            // Ensure the dropdown shows the correct selection (either existing or default)
+            const fieldToSelect = keyData.selectedAtField || defaultField?.key;
             
             // Populate options with optgroups for each object structure
             fieldGroups.forEach((group, groupIndex) => {
@@ -676,7 +680,7 @@ export function createMappingModalContent(keyData) {
                 group.fields.forEach(field => {
                     const option = createElement('option', {
                         value: field.key,
-                        selected: defaultField && field.key === defaultField.key
+                        selected: field.key === fieldToSelect
                     }, `${field.key}: ${field.preview}`);
                     optGroup.appendChild(option);
                 });


### PR DESCRIPTION
## Summary
- Enable value transformations before property selection in mapping workflow
- Fix auto-mapped identifier transformation inconsistency
- Add manual item-level reconciliation with Wikidata linking
- Redesign Step 4 as References with custom reference functionality
- Improve Step 2 mapping workflow with quick-add buttons and required property indicators
- Fix monolingual text modal language selection dropdown
- Remove excessive console.log statements and deprecated UI sections

## Key Features

### Value Transformation Improvements
- Users can now apply transformations before selecting target properties
- Fixed inconsistency in auto-mapped identifier transformations
- Ensures consistent data handling across mapping workflows

### Manual Item-Level Reconciliation
- Added ability to link items to existing Wikidata items instead of creating new ones
- New link button in reconciliation table item cells
- Linked items generate UPDATE statements instead of CREATE in export
- Modal interface for searching and selecting existing Wikidata items

### Step 4 Redesign: References
- Renamed "Wikidata Designer" to "References"
- Automatic detection of reference links from Omeka S data (API links, OCLC, ARK)
- Custom reference creation and editing functionality
- Item-specific reference management with counts and examples

### Step 2 Mapping Improvements
- Quick-add buttons for common metadata fields (labels, descriptions, aliases)
- Visual indicators for required properties
- Streamlined workflow for faster mapping configuration

## Bug Fixes
- Fixed monolingual text modal language selection dropdown behavior
- Resolved identifier transformation inconsistencies in auto-mapping

## UI/UX Improvements
- Removed deprecated "Issues" section from Wikidata designer
- Cleaned up excessive console.log statements from reconciliation modals
- Updated documentation to reflect Step 4 placeholder status

## Test Plan
- [ ] Test value transformations before and during property selection
- [ ] Verify auto-mapped identifier transformations work consistently
- [ ] Test manual item-level reconciliation with link button
- [ ] Verify linked items generate UPDATE statements in export
- [ ] Test Step 4 reference detection and custom reference creation
- [ ] Verify Step 2 quick-add buttons create correct mappings
- [ ] Test monolingual text modal language selection
- [ ] Run full E2E test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)