### PR TITLE
Add property-specific reference assignment in Step 4

### DIFF
--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -109,12 +109,9 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
             const listItem = createCustomReferenceListItem(customRef, customData, totalItems, state);
             list.appendChild(listItem);
         } else if (data && data.count > 0) {
-            // Only render auto-detected if it's not ignored and has no custom replacement
-            const isSelected = state ? state.isReferenceTypeSelected(type) : true;
-            if (isSelected) {
-                const listItem = createReferenceListItem(type, data, totalItems, state);
-                list.appendChild(listItem);
-            }
+            // Render auto-detected if it has no custom replacement
+            const listItem = createReferenceListItem(type, data, totalItems, state);
+            list.appendChild(listItem);
         }
     });
 
@@ -229,7 +226,7 @@ export function createReferenceListItem(type, data, totalItems, state = null) {
             cursor: 'pointer',
             userSelect: 'none'
         }
-    }, isSelected ? 'Selected' : 'Ignored');
+    }, isSelected ? 'Selected' : 'Unselected');
 
     // Create tooltip element
     const tooltip = createTooltip(data.examples, type);
@@ -280,7 +277,7 @@ export function createReferenceListItem(type, data, totalItems, state = null) {
             // Update visual state
             listItem.style.opacity = newIsSelected ? '1' : '0.5';
             keyName.style.textDecoration = newIsSelected ? 'none' : 'line-through';
-            status.textContent = newIsSelected ? 'Selected' : 'Ignored';
+            status.textContent = newIsSelected ? 'Selected' : 'Unselected';
             status.style.color = newIsSelected ? '#2ecc71' : '#95a5a6';
         });
 
@@ -476,7 +473,7 @@ export function createCustomReferenceListItem(customRef, data, totalItems, state
             cursor: 'pointer',
             userSelect: 'none'
         }
-    }, isSelected ? 'Selected' : 'Ignored');
+    }, isSelected ? 'Selected' : 'Unselected');
 
     // Create tooltip element
     const tooltip = createTooltip(data.examples, type);
@@ -527,7 +524,7 @@ export function createCustomReferenceListItem(customRef, data, totalItems, state
             // Update visual state
             listItem.style.opacity = newIsSelected ? '1' : '0.5';
             keyName.style.textDecoration = newIsSelected ? 'none' : 'line-through';
-            status.textContent = newIsSelected ? 'Selected' : 'Ignored';
+            status.textContent = newIsSelected ? 'Selected' : 'Unselected';
             status.style.color = newIsSelected ? '#2ecc71' : '#95a5a6';
         });
 

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -24,6 +24,9 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
     // Clear existing content
     container.innerHTML = '';
 
+    // Render properties section first
+    renderPropertiesSection(container, totalItems, state);
+
     // Check if there are any references
     const hasReferences = Object.values(summary).some(data => data.count > 0);
 
@@ -596,6 +599,127 @@ export function createAddCustomReferenceButton(state) {
 
     // Store click handler data attribute for step4.js to attach handler
     listItem.dataset.action = 'add-custom-reference';
+
+    return listItem;
+}
+
+/**
+ * Renders the properties section showing mapped properties from step 2
+ * @param {HTMLElement} container - Container element to render into
+ * @param {number} totalItems - Total number of items in dataset
+ * @param {Object} state - Application state management instance
+ */
+export function renderPropertiesSection(container, totalItems, state) {
+    if (!state) {
+        return;
+    }
+
+    const currentState = state.getState();
+    const mappedKeys = currentState.mappings?.mappedKeys || [];
+
+    if (mappedKeys.length === 0) {
+        return;
+    }
+
+    // Create section (details element)
+    const section = createElement('details', {
+        className: 'section',
+        open: true
+    });
+
+    // Create summary (header)
+    const summaryElement = createElement('summary', {
+        style: {
+            textAlign: 'left'
+        }
+    });
+
+    const titleSpan = createElement('span', {
+        className: 'section-title'
+    }, 'Mapped Properties');
+
+    const countSpan = createElement('span', {
+        className: 'section-count'
+    }, `(${mappedKeys.length})`);
+
+    summaryElement.appendChild(titleSpan);
+    summaryElement.appendChild(countSpan);
+    section.appendChild(summaryElement);
+
+    // Create list
+    const list = createElement('ul', {
+        className: 'key-list'
+    });
+
+    // Render each mapped property
+    mappedKeys.forEach(mappedKey => {
+        const listItem = createPropertyListItem(mappedKey, totalItems);
+        list.appendChild(listItem);
+    });
+
+    section.appendChild(list);
+    container.appendChild(section);
+}
+
+/**
+ * Creates a list item for a mapped property
+ * @param {Object} mappedKey - Mapped key object with property information
+ * @param {number} totalItems - Total number of items in dataset
+ * @returns {HTMLElement} List item element
+ */
+function createPropertyListItem(mappedKey, totalItems) {
+    const property = mappedKey.property;
+    const sourceKey = mappedKey.key;
+
+    // Create list item
+    const listItem = createElement('li', {
+        style: {
+            opacity: '1'
+        }
+    });
+
+    // Create compact key item wrapper
+    const keyItemCompact = createElement('div', {
+        className: 'key-item-compact',
+        style: {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%'
+        }
+    });
+
+    // Create left section (text + frequency)
+    const leftSection = createElement('div', {
+        style: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px'
+        }
+    });
+
+    // Create key name with property label
+    const keyName = createElement('span', {
+        className: 'key-name-compact'
+    }, `${property.id}: ${property.label}`);
+
+    // Create frequency indicator
+    const frequency = createElement('span', {
+        className: 'key-frequency',
+        style: {
+            fontSize: '0.9em',
+            color: '#666'
+        }
+    }, `from ${sourceKey}`);
+
+    // Append to left section
+    leftSection.appendChild(keyName);
+    leftSection.appendChild(frequency);
+
+    // Append left section to wrapper
+    keyItemCompact.appendChild(leftSection);
+
+    listItem.appendChild(keyItemCompact);
 
     return listItem;
 }

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -7,6 +7,7 @@
 import { createElement, showMessage } from '../../ui/components.js';
 import { getReferenceTypeLabel, getReferenceTypeDescription } from '../core/detector.js';
 import { getDisplayBaseUrl } from '../core/custom-references.js';
+import { openPropertyReferenceModal } from './property-reference-modal.js';
 
 /**
  * Renders the references section in the UI
@@ -696,8 +697,7 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
     // Create list item
     const listItem = createElement('li', {
         style: {
-            opacity: '1',
-            cursor: 'pointer'
+            opacity: '1'
         }
     });
 
@@ -779,40 +779,31 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
         }
     }, referenceCount > 0 ? referenceCountText : 'No references');
 
+    // Add click handler to reference count to open modal
+    if (state) {
+        referenceCountSpan.addEventListener('click', (e) => {
+            e.stopPropagation(); // Prevent list item click
+            openPropertyReferenceModal(
+                property.id,
+                property.label,
+                state,
+                onReferenceAssignment
+            );
+        });
+
+        // Add hover effect to reference count
+        referenceCountSpan.addEventListener('mouseenter', () => {
+            referenceCountSpan.style.textDecoration = 'underline';
+        });
+
+        referenceCountSpan.addEventListener('mouseleave', () => {
+            referenceCountSpan.style.textDecoration = 'none';
+        });
+    }
+
     // Append left section and count to wrapper
     keyItemCompact.appendChild(leftSection);
     keyItemCompact.appendChild(referenceCountSpan);
-
-    // Add click handler to assign references
-    if (state) {
-        listItem.addEventListener('click', () => {
-            // Get currently selected reference types
-            const selectedReferenceTypes = state.getSelectedReferenceTypes();
-
-            // Check if any references are selected
-            if (selectedReferenceTypes.length === 0) {
-                showMessage('Please select or add a reference first', 'error', 3000);
-                return;
-            }
-
-            // Assign references to this property
-            state.assignReferencesToProperty(property.id, selectedReferenceTypes);
-
-            // Trigger re-render
-            if (onReferenceAssignment) {
-                onReferenceAssignment();
-            }
-        });
-
-        // Add hover effect
-        listItem.addEventListener('mouseenter', () => {
-            listItem.style.backgroundColor = '#f5f5f5';
-        });
-
-        listItem.addEventListener('mouseleave', () => {
-            listItem.style.backgroundColor = 'transparent';
-        });
-    }
 
     listItem.appendChild(keyItemCompact);
 

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -24,9 +24,6 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
     // Clear existing content
     container.innerHTML = '';
 
-    // Render properties section first
-    renderPropertiesSection(container, totalItems, state);
-
     // Check if there are any references
     const hasReferences = Object.values(summary).some(data => data.count > 0);
 
@@ -139,6 +136,9 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
 
     section.appendChild(list);
     container.appendChild(section);
+
+    // Render properties section after references
+    renderPropertiesSection(container, totalItems, state);
 }
 
 /**
@@ -636,7 +636,7 @@ export function renderPropertiesSection(container, totalItems, state) {
 
     const titleSpan = createElement('span', {
         className: 'section-title'
-    }, 'Mapped Properties');
+    }, 'Properties Available for References');
 
     const countSpan = createElement('span', {
         className: 'section-count'
@@ -669,7 +669,6 @@ export function renderPropertiesSection(container, totalItems, state) {
  */
 function createPropertyListItem(mappedKey, totalItems) {
     const property = mappedKey.property;
-    const sourceKey = mappedKey.key;
 
     // Create list item
     const listItem = createElement('li', {
@@ -689,32 +688,54 @@ function createPropertyListItem(mappedKey, totalItems) {
         }
     });
 
-    // Create left section (text + frequency)
+    // Create left section
     const leftSection = createElement('div', {
         style: {
             display: 'flex',
             alignItems: 'center',
-            gap: '8px'
+            gap: '4px'
         }
     });
 
-    // Create key name with property label
-    const keyName = createElement('span', {
+    // Create property label text
+    const labelText = createElement('span', {
         className: 'key-name-compact'
-    }, `${property.id}: ${property.label}`);
+    }, property.label);
 
-    // Create frequency indicator
-    const frequency = createElement('span', {
-        className: 'key-frequency',
+    // Create opening parenthesis
+    const openParen = createElement('span', {
+        className: 'key-name-compact'
+    }, ' (');
+
+    // Create clickable property ID link
+    const propertyLink = createElement('a', {
+        href: `https://www.wikidata.org/wiki/Property:${property.id}`,
+        target: '_blank',
+        rel: 'noopener noreferrer',
         style: {
-            fontSize: '0.9em',
-            color: '#666'
+            color: '#0066cc',
+            textDecoration: 'none'
         }
-    }, `from ${sourceKey}`);
+    }, property.id);
 
-    // Append to left section
-    leftSection.appendChild(keyName);
-    leftSection.appendChild(frequency);
+    // Add hover effect to link
+    propertyLink.addEventListener('mouseenter', () => {
+        propertyLink.style.textDecoration = 'underline';
+    });
+    propertyLink.addEventListener('mouseleave', () => {
+        propertyLink.style.textDecoration = 'none';
+    });
+
+    // Create closing parenthesis
+    const closeParen = createElement('span', {
+        className: 'key-name-compact'
+    }, ')');
+
+    // Append all elements to left section
+    leftSection.appendChild(labelText);
+    leftSection.appendChild(openParen);
+    leftSection.appendChild(propertyLink);
+    leftSection.appendChild(closeParen);
 
     // Append left section to wrapper
     keyItemCompact.appendChild(leftSection);

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -697,7 +697,8 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
     // Create list item
     const listItem = createElement('li', {
         style: {
-            opacity: '1'
+            opacity: '1',
+            cursor: 'pointer'
         }
     });
 
@@ -806,6 +807,37 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
     keyItemCompact.appendChild(referenceCountSpan);
 
     listItem.appendChild(keyItemCompact);
+
+    // Add click handler for quick-assign (clicking anywhere on list item)
+    if (state) {
+        listItem.addEventListener('click', () => {
+            // Get currently selected reference types
+            const selectedReferenceTypes = state.getSelectedReferenceTypes();
+
+            // Check if any references are selected
+            if (selectedReferenceTypes.length === 0) {
+                showMessage('Please select or add a reference first', 'error', 3000);
+                return;
+            }
+
+            // Assign references to this property
+            state.assignReferencesToProperty(property.id, selectedReferenceTypes);
+
+            // Trigger re-render
+            if (onReferenceAssignment) {
+                onReferenceAssignment();
+            }
+        });
+
+        // Add hover effect
+        listItem.addEventListener('mouseenter', () => {
+            listItem.style.backgroundColor = '#f5f5f5';
+        });
+
+        listItem.addEventListener('mouseleave', () => {
+            listItem.style.backgroundColor = 'transparent';
+        });
+    }
 
     return listItem;
 }

--- a/src/js/references/ui/property-reference-modal.js
+++ b/src/js/references/ui/property-reference-modal.js
@@ -1,0 +1,296 @@
+/**
+ * Property Reference Modal UI Module
+ * Handles the modal interface for assigning references to properties
+ * @module references/ui/property-reference-modal
+ */
+
+import { createElement, createButton } from '../../ui/components.js';
+import { getReferenceTypeLabel, getReferenceTypeDescription } from '../core/detector.js';
+import { getDisplayBaseUrl } from '../core/custom-references.js';
+
+/**
+ * Opens a modal to manage reference assignments for a property
+ * @param {string} propertyId - Wikidata property ID (e.g., 'P1476')
+ * @param {string} propertyLabel - Human-readable property label
+ * @param {Object} state - Application state management instance
+ * @param {Function} onUpdate - Callback to re-render property list
+ */
+export function openPropertyReferenceModal(propertyId, propertyLabel, state, onUpdate) {
+    const currentState = state.getState();
+
+    // Get all available references
+    const availableReferences = getAllAvailableReferences(state);
+
+    // Get currently assigned references
+    const assignedReferences = state.getPropertyReferences(propertyId);
+
+    // Create modal overlay
+    const overlay = createElement('div', {
+        className: 'modal-overlay',
+        style: {
+            position: 'fixed',
+            top: '0',
+            left: '0',
+            width: '100%',
+            height: '100%',
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: '1000'
+        }
+    });
+
+    // Create modal container
+    const modal = createElement('div', {
+        className: 'modal property-reference-modal',
+        style: {
+            backgroundColor: 'white',
+            borderRadius: '8px',
+            padding: '24px',
+            maxWidth: '500px',
+            maxHeight: '80vh',
+            overflow: 'auto',
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
+        }
+    });
+
+    // Create modal header
+    const header = createElement('div', {
+        className: 'modal-header',
+        style: {
+            marginBottom: '16px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center'
+        }
+    });
+
+    const title = createElement('h3', {
+        style: { margin: '0' }
+    }, `Assign References to ${propertyLabel}`);
+
+    const closeButton = createButton('×', {
+        className: 'close-button',
+        style: {
+            background: 'none',
+            border: 'none',
+            fontSize: '24px',
+            cursor: 'pointer',
+            padding: '0',
+            width: '32px',
+            height: '32px'
+        },
+        onClick: () => {
+            document.body.removeChild(overlay);
+        }
+    });
+
+    header.appendChild(title);
+    header.appendChild(closeButton);
+
+    // Create modal body
+    const body = createElement('div', {
+        className: 'modal-body'
+    });
+
+    // Description
+    const description = createElement('p', {
+        style: {
+            marginBottom: '16px',
+            color: '#666',
+            fontSize: '14px'
+        }
+    }, 'Select which references should be used for this property.');
+
+    body.appendChild(description);
+
+    // Create reference list
+    const referenceList = createElement('div', {
+        className: 'reference-list',
+        style: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '12px'
+        }
+    });
+
+    // Track current selections
+    let currentAssignedReferences = [...assignedReferences];
+
+    // Render each available reference
+    availableReferences.forEach(ref => {
+        const isAssigned = currentAssignedReferences.includes(ref.id);
+        const referenceItem = createReferenceListItem(ref, isAssigned, (checked) => {
+            // Update current selections
+            if (checked) {
+                if (!currentAssignedReferences.includes(ref.id)) {
+                    currentAssignedReferences.push(ref.id);
+                }
+            } else {
+                currentAssignedReferences = currentAssignedReferences.filter(id => id !== ref.id);
+            }
+
+            // Update state immediately
+            state.assignReferencesToProperty(propertyId, currentAssignedReferences);
+
+            // Trigger re-render of property list
+            if (onUpdate) {
+                onUpdate();
+            }
+        });
+
+        referenceList.appendChild(referenceItem);
+    });
+
+    body.appendChild(referenceList);
+
+    // Create footer with close button
+    const footer = createElement('div', {
+        className: 'modal-footer',
+        style: {
+            marginTop: '24px',
+            display: 'flex',
+            justifyContent: 'flex-end'
+        }
+    });
+
+    const doneButton = createButton('Done', {
+        className: 'button button--primary',
+        onClick: () => {
+            document.body.removeChild(overlay);
+        }
+    });
+
+    footer.appendChild(doneButton);
+
+    // Assemble modal
+    modal.appendChild(header);
+    modal.appendChild(body);
+    modal.appendChild(footer);
+    overlay.appendChild(modal);
+
+    // Close on backdrop click
+    overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) {
+            document.body.removeChild(overlay);
+        }
+    });
+
+    // Add to document
+    document.body.appendChild(overlay);
+}
+
+/**
+ * Gets all available references (auto-detected + custom)
+ * @param {Object} state - Application state management instance
+ * @returns {Array} Array of reference objects with {id, name, baseUrl}
+ */
+function getAllAvailableReferences(state) {
+    const currentState = state.getState();
+    const references = [];
+
+    // Get auto-detected reference types
+    const summary = currentState.references?.summary || {};
+    const autoDetectedTypes = ['omeka-item', 'oclc', 'ark'];
+
+    autoDetectedTypes.forEach(type => {
+        const data = summary[type];
+        if (data && data.count > 0) {
+            references.push({
+                id: type,
+                name: getReferenceTypeLabel(type),
+                baseUrl: getReferenceTypeDescription(type, data),
+                type: 'auto-detected'
+            });
+        }
+    });
+
+    // Get custom references
+    const customReferences = state.getCustomReferences() || [];
+    customReferences.forEach(customRef => {
+        references.push({
+            id: customRef.id,
+            name: customRef.name,
+            baseUrl: getDisplayBaseUrl(customRef.baseUrl),
+            type: 'custom'
+        });
+    });
+
+    return references;
+}
+
+/**
+ * Creates a list item for a reference with checkbox
+ * @param {Object} reference - Reference object with {id, name, baseUrl}
+ * @param {boolean} isChecked - Whether the checkbox should be checked
+ * @param {Function} onChange - Callback when checkbox changes
+ * @returns {HTMLElement} Reference list item
+ */
+function createReferenceListItem(reference, isChecked, onChange) {
+    const item = createElement('div', {
+        className: 'reference-item',
+        style: {
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '12px',
+            padding: '12px',
+            border: '1px solid #e0e0e0',
+            borderRadius: '4px',
+            backgroundColor: '#f9f9f9'
+        }
+    });
+
+    // Create checkbox
+    const checkbox = createElement('input', {
+        type: 'checkbox',
+        checked: isChecked,
+        style: {
+            marginTop: '2px',
+            cursor: 'pointer'
+        }
+    });
+
+    // Handle checkbox change
+    checkbox.addEventListener('change', (e) => {
+        onChange(e.target.checked);
+    });
+
+    // Create content section
+    const content = createElement('div', {
+        style: {
+            flex: '1',
+            cursor: 'pointer'
+        }
+    });
+
+    // Make content clickable to toggle checkbox
+    content.addEventListener('click', () => {
+        checkbox.checked = !checkbox.checked;
+        onChange(checkbox.checked);
+    });
+
+    // Reference name
+    const name = createElement('div', {
+        style: {
+            fontWeight: '500',
+            marginBottom: '4px'
+        }
+    }, reference.name);
+
+    // Reference base URL
+    const baseUrl = createElement('div', {
+        style: {
+            fontSize: '12px',
+            color: '#666'
+        }
+    }, reference.baseUrl);
+
+    content.appendChild(name);
+    content.appendChild(baseUrl);
+
+    item.appendChild(checkbox);
+    item.appendChild(content);
+
+    return item;
+}

--- a/src/js/references/ui/property-reference-modal.js
+++ b/src/js/references/ui/property-reference-modal.js
@@ -196,9 +196,8 @@ function getAllAvailableReferences(state) {
 
     autoDetectedTypes.forEach(type => {
         const data = summary[type];
-        const isSelected = state.isReferenceTypeSelected(type);
-        // Only include references that are selected (not ignored) and have data
-        if (data && data.count > 0 && isSelected) {
+        // Include all references that have data, regardless of selection status
+        if (data && data.count > 0) {
             references.push({
                 id: type,
                 name: getReferenceTypeLabel(type),
@@ -208,18 +207,15 @@ function getAllAvailableReferences(state) {
         }
     });
 
-    // Get custom references (only selected ones)
+    // Get all custom references, regardless of selection status
     const customReferences = state.getCustomReferences() || [];
     customReferences.forEach(customRef => {
-        const isSelected = state.isReferenceTypeSelected(customRef.id);
-        if (isSelected) {
-            references.push({
-                id: customRef.id,
-                name: customRef.name,
-                baseUrl: getDisplayBaseUrl(customRef.baseUrl),
-                type: 'custom'
-            });
-        }
+        references.push({
+            id: customRef.id,
+            name: customRef.name,
+            baseUrl: getDisplayBaseUrl(customRef.baseUrl),
+            type: 'custom'
+        });
     });
 
     return references;

--- a/src/js/steps/step4.js
+++ b/src/js/steps/step4.js
@@ -117,7 +117,7 @@ function handleStep4Entry(state, container) {
                         // Add as new custom reference (converted from auto-detected)
                         state.addCustomReference(customRef);
 
-                        // Hide the original auto-detected reference by toggling it to "ignored"
+                        // Unselect the original auto-detected reference
                         if (customRef.originalType && state.isReferenceTypeSelected(customRef.originalType)) {
                             state.toggleReferenceType(customRef.originalType);
                         }


### PR DESCRIPTION
## Summary
- Display mapped properties from Step 2 in Step 4 References section
- Enable property-specific reference assignment with quick-assign and detailed modal
- Fix reference display bugs and update terminology

## Features Added

### Property Display & Quick Assignment
- Added "Properties Available for References" section showing all mapped properties
- Display format: `Property Label (P-ID)` with clickable Wikidata links
- Quick-assign: Click any property to assign all currently selected references
- Reference count indicator on each property (e.g., "3 references")

### Property Reference Management Modal
- Detailed modal for managing references assigned to specific properties
- Shows all available references (auto-detected and custom) regardless of selection status
- Toggle references on/off with visual green/gray blocks and checkmarks
- Changes update immediately in property list

### Reference Display Improvements
- Always display all references (selected and unselected)
- Unselected references show with reduced opacity and strikethrough
- Terminology: Changed "Ignored" to "Unselected" throughout UI
- Fixed bug where adding custom references caused unselected references to disappear

## Test Plan
- [ ] Load data in Step 1, map properties in Step 2
- [ ] Navigate to Step 4 and verify mapped properties list appears
- [ ] Select/unselect references in "Available References"
- [ ] Click a property to quick-assign selected references
- [ ] Click reference count to open modal
- [ ] Toggle references in modal and verify count updates
- [ ] Add custom reference and verify unselected references remain visible
- [ ] Save and load project, verify reference assignments persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)