### PR TITLE
QuickStatements Export Improvements: Language Codes and Property References

### DIFF
--- a/src/js/reconciliation/ui/reconciliation-modal.js
+++ b/src/js/reconciliation/ui/reconciliation-modal.js
@@ -1040,17 +1040,29 @@ export function createModalInteractionHandlers(dependencies) {
 
         confirmCustomValue() {
             if (!window.currentModalContext) return;
-            
-            const currentValue = window.currentModalContext.currentValue || window.currentModalContext.transformedValue;
-            
-            markCellAsReconciled(window.currentModalContext, {
-                type: 'custom',
-                value: currentValue,
-                datatype: window.currentModalContext.dataType
-            });
-            
+
+            // Check if we have enhanced confirmation data from specialized modals (e.g., string-modal.js)
+            // This data includes language codes for monolingual text and other type-specific information
+            let reconciliationData;
+
+            if (window.currentModalContext.confirmationData) {
+                // Use the enhanced confirmation data that includes all type-specific fields
+                // (e.g., language, languageLabel for monolingualtext; precision for time; etc.)
+                reconciliationData = window.currentModalContext.confirmationData;
+            } else {
+                // Fallback to basic reconciliation data for backward compatibility
+                const currentValue = window.currentModalContext.currentValue || window.currentModalContext.transformedValue;
+                reconciliationData = {
+                    type: 'custom',
+                    value: currentValue,
+                    datatype: window.currentModalContext.dataType
+                };
+            }
+
+            markCellAsReconciled(window.currentModalContext, reconciliationData);
+
             modalUI.closeModal();
-            
+
             // Auto-advance if enabled
             if (getAutoAdvanceSetting()) {
                 setTimeout(() => {

--- a/src/js/steps/export.js
+++ b/src/js/steps/export.js
@@ -421,9 +421,8 @@ export function setupExportStep(state) {
         const manualProperties = currentState.mappings?.manualProperties || [];
         
         // Get references for statements
-        const oldReferences = currentState.references || [];
-        const globalReferences = currentState.globalReferences || [];
-        const allReferences = [...oldReferences, ...globalReferences];
+        const customReferences = currentState.references?.customReferences || [];
+        const allReferences = [...customReferences];
 
         const entitySchema = currentState.entitySchema;
         

--- a/src/js/steps/export.js
+++ b/src/js/steps/export.js
@@ -510,7 +510,12 @@ export function setupExportStep(state) {
 
                                         // For label/description/alias properties, format with language code
                                         // QuickStatements format: Len (label-en), Den (description-en), Aen (alias-en)
-                                        if (wikidataPropertyId === 'label' || wikidataPropertyId === 'description' || wikidataPropertyId === 'alias') {
+                                        // Handle both singular and plural forms (alias/aliases)
+                                        const isLabel = wikidataPropertyId === 'label' || wikidataPropertyId === 'labels';
+                                        const isDescription = wikidataPropertyId === 'description' || wikidataPropertyId === 'descriptions';
+                                        const isAlias = wikidataPropertyId === 'alias' || wikidataPropertyId === 'aliases';
+
+                                        if (isLabel || isDescription || isAlias) {
                                             const languageCode = match.language || 'en'; // Default to 'en' if no language specified
 
                                             // Warn if language code is missing
@@ -519,13 +524,15 @@ export function setupExportStep(state) {
                                             }
 
                                             // Map property type to QuickStatements prefix
-                                            const prefixMap = {
-                                                'label': 'L',
-                                                'description': 'D',
-                                                'alias': 'A'
-                                            };
+                                            let prefix;
+                                            if (isLabel) {
+                                                prefix = 'L';
+                                            } else if (isDescription) {
+                                                prefix = 'D';
+                                            } else if (isAlias) {
+                                                prefix = 'A';
+                                            }
 
-                                            const prefix = prefixMap[wikidataPropertyId];
                                             wikidataPropertyId = `${prefix}${languageCode}`;
                                         }
                                     } else {


### PR DESCRIPTION
## Summary
- Fix labels, descriptions, and aliases export with proper language codes (Lxx, Dxx, Axx format)
- Add property-specific reference export support
- Fix language code preservation during reconciliation
- Handle both singular and plural forms of property IDs

## Changes

### Language Code Fixes
- **Export formatting**: Labels, descriptions, and aliases now correctly export with QuickStatements language code format (e.g., `Len`, `Dnl`, `Afr`)
- **Reconciliation preservation**: Language codes selected in monolingual text modal are now properly saved to state and preserved throughout the workflow
- **Plural forms support**: Both singular (`label`, `description`, `alias`) and plural (`labels`, `descriptions`, `aliases`) property IDs are correctly handled

### Reference Export
- **Property-specific references**: References assigned to specific properties in Step 4 are now exported in QuickStatements format using S854 (reference URL)
- **Reference resolution**: New `getReferencesForPropertyAndItem()` helper function retrieves references assigned to properties
- **Support for all reference types**: Works with both auto-detected references (omeka-item, oclc, ark) and custom references

## Technical Details

### Files Modified
- `src/js/steps/export.js`: Added language code formatting and reference export logic
- `src/js/reconciliation/ui/reconciliation-modal.js`: Fixed confirmationData preservation from specialized modals

### QuickStatements Format
References are exported as:
```
ITEM_ID	PROPERTY_ID	VALUE	S854	"reference_url"
```

Labels/descriptions/aliases are exported as:
```
LAST	Len	"English label"
LAST	Dnl	"Dutch description"
LAST	Afr	"French alias"
```

## Test Plan
- Re-reconcile items with monolingual text (labels, descriptions, aliases) and verify language codes are saved
- Assign references to properties in Step 4
- Export to QuickStatements and verify:
  - Labels show as `Lxx` format with correct language codes
  - Descriptions show as `Dxx` format
  - Aliases show as `Axx` format
  - References appear as S854 statements for properties they're assigned to

🤖 Generated with [Claude Code](https://claude.com/claude-code)