### PR TITLE
Fix identifier detection error handling

### DIFF
--- a/src/js/utils/identifier-detection.js
+++ b/src/js/utils/identifier-detection.js
@@ -405,26 +405,39 @@ export async function createIdentifierMapping(fieldKey, detection, sampleValue) 
     let constraints = null;
     let constraintsFetched = false;
     let constraintsError = null;
-    
-    try {
-        // Fetch comprehensive property information
-        propertyInfo = await getPropertyInfo(detection.propertyId);
-        
-        // Fetch property constraints for validation and formatting
-        constraints = await getPropertyConstraints(detection.propertyId);
-        constraintsFetched = true;
-        
-    } catch (error) {
-        console.warn(`Auto-mapping: Failed to fetch constraints for ${detection.propertyId}:`, error);
-        constraintsError = error.message;
-        
-        // Use fallback property info from detection
+
+    // Only fetch property info if propertyId is not null
+    // Some identifier types (wikidata, iso639-1) map directly to items, not properties
+    if (detection.propertyId !== null) {
+        try {
+            // Fetch comprehensive property information
+            propertyInfo = await getPropertyInfo(detection.propertyId);
+
+            // Fetch property constraints for validation and formatting
+            constraints = await getPropertyConstraints(detection.propertyId);
+            constraintsFetched = true;
+
+        } catch (error) {
+            console.warn(`Auto-mapping: Failed to fetch constraints for ${detection.propertyId}:`, error);
+            constraintsError = error.message;
+
+            // Use fallback property info from detection
+            propertyInfo = {
+                id: detection.propertyId,
+                label: detection.label,
+                description: detection.description,
+                datatype: 'external-id',
+                datatypeLabel: 'External identifier'
+            };
+        }
+    } else {
+        // For identifier types without a property (direct item mapping)
         propertyInfo = {
-            id: detection.propertyId,
+            id: null,
             label: detection.label,
             description: detection.description,
-            datatype: 'external-id',
-            datatypeLabel: 'External identifier'
+            datatype: 'wikibase-item',
+            datatypeLabel: 'Wikidata item'
         };
     }
     


### PR DESCRIPTION
## Summary
- Fixed null property ID handling in identifier detection system
- Skipped identifiers without property mappings from auto-detection UI
- Eliminated console errors when processing wikidata and iso639-1 identifier types

## Changes Made
1. **identifier-detection.js**: Added null check before fetching property info from Wikidata API
   - Prevents API calls with null property IDs
   - Provides fallback property info for direct item mappings (wikidata, iso639-1)
   
2. **mapping-lists.js**: Filters out identifiers without property mappings
   - Skips adding them to the UI
   - Logs detection details to console for debugging

## Test Plan
- [x] Verify no console errors in Step 2 when identifiers are detected
- [x] Confirm wikidata and iso639-1 identifiers are logged but not displayed
- [x] Test that valid identifiers (ARK, VIAF, etc.) still auto-map correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)