### PR TITLE
Fix modal closing when text selection drags end outside modal

### DIFF
--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -323,10 +323,20 @@ export function openCustomReferenceModal(state, onSubmit, options = {}) {
     setTimeout(() => nameInput.focus(), 100);
 
     // Close on overlay click
+    // Track mousedown to distinguish between clicks and drag-end events
+    let mouseDownOnOverlay = false;
+
+    overlay.addEventListener('mousedown', (e) => {
+        mouseDownOnOverlay = (e.target === overlay);
+    });
+
     overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) {
+        // Only close if both mousedown and mouseup (click) happened on the overlay
+        // This prevents text selection drags from closing the modal
+        if (e.target === overlay && mouseDownOnOverlay) {
             document.body.removeChild(overlay);
         }
+        mouseDownOnOverlay = false;
     });
 
     // Close on Escape key

--- a/src/js/references/ui/property-reference-modal.js
+++ b/src/js/references/ui/property-reference-modal.js
@@ -171,10 +171,20 @@ export function openPropertyReferenceModal(propertyId, propertyLabel, state, onU
     overlay.appendChild(modal);
 
     // Close on backdrop click
+    // Track mousedown to distinguish between clicks and drag-end events
+    let mouseDownOnOverlay = false;
+
+    overlay.addEventListener('mousedown', (e) => {
+        mouseDownOnOverlay = (e.target === overlay);
+    });
+
     overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) {
+        // Only close if both mousedown and mouseup (click) happened on the overlay
+        // This prevents text selection drags from closing the modal
+        if (e.target === overlay && mouseDownOnOverlay) {
             document.body.removeChild(overlay);
         }
+        mouseDownOnOverlay = false;
     });
 
     // Add to document

--- a/src/js/ui/modal-ui.js
+++ b/src/js/ui/modal-ui.js
@@ -106,16 +106,26 @@ export function setupModalUI() {
         if (closeModalBtn) {
             closeModalBtn.addEventListener('click', closeModal);
         }
-        
+
         // Setup clicking outside modal to close
+        // Track mousedown to distinguish between clicks and drag-end events
         if (modalContainer) {
+            let mouseDownOnContainer = false;
+
+            modalContainer.addEventListener('mousedown', (e) => {
+                mouseDownOnContainer = (e.target === modalContainer);
+            });
+
             modalContainer.addEventListener('click', (e) => {
-                if (e.target === modalContainer) {
+                // Only close if both mousedown and mouseup (click) happened on the container
+                // This prevents text selection drags from closing the modal
+                if (e.target === modalContainer && mouseDownOnContainer) {
                     closeModal();
                 }
+                mouseDownOnContainer = false;
             });
         }
-        
+
         // Ensure modal is hidden initially by setting the style directly
         if (modalContainer) {
             modalContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- Fixed bug where text selection drags ending outside modals incorrectly closed the modals
- Now tracks `mousedown` events to distinguish between actual clicks and drag-end events

## Changes
- **src/js/ui/modal-ui.js** - Updated main modal system overlay click handler
- **src/js/references/ui/property-reference-modal.js** - Updated reference modal overlay click handler
- **src/js/references/ui/custom-reference-modal.js** - Updated custom reference modal overlay click handler

## Technical Details
The browser fires a `click` event when `mouseup` occurs on the overlay, even if `mousedown` happened inside the modal during text selection. Now we track where `mousedown` occurred and only close the modal if both `mousedown` and `click` happen on the overlay.

## Test plan
- [ ] Open any modal with text content
- [ ] Click inside modal text and drag to select
- [ ] Release mouse button outside modal (on overlay)
- [ ] Verify modal stays open
- [ ] Click directly on overlay (without dragging)
- [ ] Verify modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)