### PR TITLE
Fix Step 4 reference detection and display issues

### DIFF
--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -46,7 +46,9 @@ function getItemDisplayName(item, index, reconciliationData) {
 export function openCustomReferenceModal(state, onSubmit, options = {}) {
     const { isEdit = false, existingReference = null } = options;
     const currentState = state.getState();
-    const items = currentState.fetchedData || [];
+    const fetchedData = currentState.fetchedData;
+    // Ensure items is always an array (handle both single item and array cases)
+    const items = !fetchedData ? [] : (Array.isArray(fetchedData) ? fetchedData : [fetchedData]);
     const reconciliationData = currentState.reconciliationData || {};
 
     // Create modal overlay

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -707,7 +707,27 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
 
     // Get current reference count for this property
     const assignedReferences = state ? state.getPropertyReferences(property.id) : [];
-    const referenceCount = assignedReferences.length;
+
+    // Calculate total count of reference URLs (not just types)
+    let referenceCount = 0;
+    if (state && assignedReferences.length > 0) {
+        const currentState = state.getState();
+        const summary = currentState.references?.summary || {};
+        const customReferences = currentState.references?.customReferences || [];
+
+        assignedReferences.forEach(refType => {
+            // Check if it's an auto-detected reference
+            if (summary[refType]) {
+                referenceCount += summary[refType].count || 0;
+            } else {
+                // Check if it's a custom reference
+                const customRef = customReferences.find(ref => ref.id === refType);
+                if (customRef) {
+                    referenceCount += customRef.count || 0;
+                }
+            }
+        });
+    }
 
     // Create list item
     const listItem = createElement('li', {

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -25,16 +25,12 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
     // Clear existing content
     container.innerHTML = '';
 
-    // Check if there are any references
-    const hasReferences = Object.values(summary).some(data => data.count > 0);
+    // Check if there are any auto-detected references
+    const hasAutoDetectedReferences = Object.values(summary).some(data => data.count > 0);
 
-    if (!hasReferences) {
-        const emptyMessage = createElement('p', {
-            className: 'placeholder'
-        }, 'No references detected in the API data.');
-        container.appendChild(emptyMessage);
-        return;
-    }
+    // Check if there are any custom references in state
+    const customReferences = state ? state.getCustomReferences() : [];
+    const hasCustomReferences = customReferences.length > 0;
 
     // Calculate total items with at least one reference
     const itemsWithReferences = new Set();
@@ -42,6 +38,11 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
         if (data.examples) {
             data.examples.forEach(example => itemsWithReferences.add(example.itemId));
         }
+    });
+
+    // Add custom reference items to the count
+    customReferences.forEach(customRef => {
+        customRef.items.forEach(item => itemsWithReferences.add(item.itemId));
     });
 
     // Create section (details element)
@@ -73,6 +74,19 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
     const list = createElement('ul', {
         className: 'key-list'
     });
+
+    // If no auto-detected or custom references, show helpful message
+    if (!hasAutoDetectedReferences && !hasCustomReferences) {
+        const emptyMessage = createElement('li', {
+            className: 'placeholder',
+            style: {
+                fontStyle: 'italic',
+                color: '#666',
+                padding: '8px 12px'
+            }
+        }, 'No references auto-detected. You can add custom references below.');
+        list.appendChild(emptyMessage);
+    }
 
     // Build a map of originalType -> custom reference for position preservation
     const customByOriginalType = new Map();


### PR DESCRIPTION
## Summary
- Fixed Step 4 UI to display properly when no references are auto-detected
- Fixed custom reference modal handling of non-array fetchedData
- Fixed reference count to show actual number of URLs instead of reference types

## Changes

### 1. Step 4 UI Display (src/js/references/ui/display.js)
- Removed early return that blocked UI when no auto-detected references exist
- Check for both auto-detected and custom references before showing empty state
- Include custom reference items in the item count calculation
- Show helpful message: "No references auto-detected. You can add custom references below."
- Always render "Add custom reference" button and properties section
- Users can now add custom references even when auto-detection finds nothing

### 2. Custom Reference Modal (src/js/references/ui/custom-reference-modal.js)
- Fixed TypeError: "items.forEach is not a function"
- Ensure items is always an array before calling forEach
- Handle cases where fetchedData is a single object instead of array

### 3. Reference Count Display (src/js/references/ui/display.js)
- Fixed reference count indicator to show actual number of URLs
- Previously showed number of reference types (e.g., "3 references" for 3 types)
- Now shows actual total (e.g., "180 references" if those 3 types cover 180 items)
- Correctly sums up counts from both auto-detected and custom references

## Test plan
- [ ] Navigate to Step 4 with data that has no auto-detected references
- [ ] Verify "Add custom reference" button is visible and clickable
- [ ] Verify properties section displays correctly
- [ ] Add a custom reference and verify it appears in the list
- [ ] Click on a property to assign references
- [ ] Verify reference count shows actual number of URLs, not just type count

🤖 Generated with [Claude Code](https://claude.com/claude-code)