### PR TITLE
Fix QuickStatements export format compliance

### DIFF
--- a/src/js/steps/export.js
+++ b/src/js/steps/export.js
@@ -601,10 +601,10 @@ export function setupExportStep(state) {
                                             // Transform property ID to QuickStatements format
                                             currentPropertyId = `${prefix}${languageCode}`;
                                         } else {
-                                            // Format: P1476 en"value" - language code prefixes the value
+                                            // Format: P1476 en:"value" - language code with colon prefixes the value
                                             // Don't escape the value yet, add language prefix first
                                             const escapedValue = match.value.replace(/"/g, '""').replace(/\n/g, ' ').replace(/\r/g, ' ');
-                                            value = `${languageCode}"${escapedValue}"`;
+                                            value = `${languageCode}:"${escapedValue}"`;
                                         }
                                     } else {
                                         value = escapeQuickStatementsString(match.value);

--- a/src/js/steps/export.js
+++ b/src/js/steps/export.js
@@ -642,8 +642,18 @@ export function setupExportStep(state) {
                     return 0;
                 });
 
+                // Deduplicate statements - keep only unique statements
+                const seenStatements = new Set();
+                const uniqueStatements = itemStatements.filter(({ statement }) => {
+                    if (seenStatements.has(statement)) {
+                        return false;
+                    }
+                    seenStatements.add(statement);
+                    return true;
+                });
+
                 // Output statements in sorted order
-                itemStatements.forEach(({ statement }) => {
+                uniqueStatements.forEach(({ statement }) => {
                     quickStatementsText += statement + '\n';
                 });
                 


### PR DESCRIPTION
## Summary
- Labels now appear first in QuickStatements output (required by QS format)
- Fixed monolingual text syntax: `P1476 en:"English text"` format
- Added deduplication to prevent identical statements

## Changes
1. **Label ordering**: Collects all statements per item, sorts to ensure labels appear before other properties
2. **Monolingual text format**: 
   - Labels/descriptions/aliases: `Len "value"` (language in property ID)
   - Regular monolingual properties: `P1476 en:"value"` (language prefix with colon in value)
3. **Statement deduplication**: Filters out duplicate statements using Set-based tracking

## Technical Details
- Modified `src/js/steps/export.js` QuickStatements generation logic
- Maintains backward compatibility with existing reconciliation data
- All changes preserve existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)