### PR TITLE
Step 4 References: UX improvements and bug fixes

### DIFF
--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -182,8 +182,8 @@ export function openCustomReferenceModal(state, onSubmit, options = {}) {
             }
         }, displayName);
 
-        // Pre-fill value from existing reference if in edit mode
-        const existingUrl = existingUrlsMap.get(itemId) || '';
+        // Pre-fill value from existing reference if in edit mode, or with "https://" for new references
+        const existingUrl = existingUrlsMap.get(itemId) || (isEdit ? '' : 'https://');
 
         const itemInput = createInput('text', {
             placeholder: 'https://example.com/reference',

--- a/src/js/references/ui/custom-reference-modal.js
+++ b/src/js/references/ui/custom-reference-modal.js
@@ -11,26 +11,16 @@ import { createCustomReference, validateCustomReference } from '../core/custom-r
  * Gets the display name for an item based on reconciliation status
  * @param {Object} item - The Omeka item
  * @param {number} index - Item index
- * @param {Object} reconciliationData - Reconciliation data from state
+ * @param {Object} linkedItems - Linked items mapping from state
  * @returns {string} Display name for the item
  */
-function getItemDisplayName(item, index, reconciliationData) {
+function getItemDisplayName(item, index, linkedItems) {
     const itemId = `item-${index}`;
-    const itemData = reconciliationData?.[itemId];
 
-    // Check if item has a linked Wikidata QID
-    if (itemData && itemData.properties) {
-        // Look through properties to find a reconciled Wikidata item
-        for (const propertyKey in itemData.properties) {
-            const propertyData = itemData.properties[propertyKey];
-            if (propertyData.reconciled && Array.isArray(propertyData.reconciled)) {
-                for (const reconciledItem of propertyData.reconciled) {
-                    if (reconciledItem.selectedMatch && reconciledItem.selectedMatch.type === 'wikidata') {
-                        return `Linked QID: ${reconciledItem.selectedMatch.id}`;
-                    }
-                }
-            }
-        }
+    // Check if item is linked to an existing Wikidata item
+    const qid = linkedItems?.[itemId];
+    if (qid) {
+        return qid;
     }
 
     // No linked QID found, show as new item
@@ -49,7 +39,7 @@ export function openCustomReferenceModal(state, onSubmit, options = {}) {
     const fetchedData = currentState.fetchedData;
     // Ensure items is always an array (handle both single item and array cases)
     const items = !fetchedData ? [] : (Array.isArray(fetchedData) ? fetchedData : [fetchedData]);
-    const reconciliationData = currentState.reconciliationData || {};
+    const linkedItems = currentState.linkedItems || {};
 
     // Create modal overlay
     const overlay = createElement('div', {
@@ -172,7 +162,7 @@ export function openCustomReferenceModal(state, onSubmit, options = {}) {
     items.forEach((item, index) => {
         // Use same itemId format as detector: @id or id or fallback to item-${index}
         const itemId = item['@id'] || item.id || `item-${index}`;
-        const displayName = getItemDisplayName(item, index, reconciliationData);
+        const displayName = getItemDisplayName(item, index, linkedItems);
 
         const itemRow = createElement('div', {
             className: 'item-row',

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -728,7 +728,7 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
     const property = mappedKey.property;
 
     // Check if this is a manual property that cannot accept references
-    const cannotAcceptReferences = ['label', 'description', 'alias'].includes(property.id);
+    const cannotAcceptReferences = ['label', 'description', 'aliases'].includes(property.id);
 
     // Get current reference count for this property
     const assignedReferences = state ? state.getPropertyReferences(property.id) : [];
@@ -852,7 +852,7 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
             cursor: cannotAcceptReferences ? 'default' : 'pointer',
             userSelect: 'none'
         }
-    }, cannotAcceptReferences ? 'No references' : (referenceCount > 0 ? referenceCountText : 'No references'));
+    }, cannotAcceptReferences ? 'No reference accepted' : (referenceCount > 0 ? referenceCountText : 'No references'));
 
     // Add click handler to reference count to open modal (only if references are allowed)
     if (state && !cannotAcceptReferences) {

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -78,7 +78,7 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
             margin: '8px 0 12px 0',
             padding: '0 12px'
         }
-    }, 'References are detected automatically from your data. Click "Add custom reference" to add more by hand.');
+    }, 'Some references are detected automatically from your data. Click "Add custom reference" to add more by hand.');
     section.appendChild(guideText);
 
     // Create list
@@ -681,7 +681,7 @@ export function renderPropertiesSection(container, totalItems, state) {
             margin: '8px 0 12px 0',
             padding: '0 12px'
         }
-    }, 'Click a property to assign selected references. Click the reference count to customize which references are assigned.');
+    }, 'Click a property to assign selected references. Click the reference counter of a property to customize which references are assigned.');
     section.appendChild(guideText);
 
     // Create list

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -863,13 +863,8 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
             // Get currently selected reference types
             const selectedReferenceTypes = state.getSelectedReferenceTypes();
 
-            // Check if any references are selected
-            if (selectedReferenceTypes.length === 0) {
-                showMessage('Please select or add a reference first', 'error', 3000);
-                return;
-            }
-
-            // Assign references to this property
+            // If no references are selected, remove all references from this property
+            // Otherwise, assign the selected references
             state.assignReferencesToProperty(property.id, selectedReferenceTypes);
 
             // Trigger re-render

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -70,6 +70,17 @@ export function renderReferencesSection(summary, container, totalItems = 0, stat
     summaryElement.appendChild(countSpan);
     section.appendChild(summaryElement);
 
+    // Add guide text
+    const guideText = createElement('p', {
+        style: {
+            fontSize: '13px',
+            color: '#666',
+            margin: '8px 0 12px 0',
+            padding: '0 12px'
+        }
+    }, 'References are detected automatically from your data. Click "Add custom reference" to add more by hand.');
+    section.appendChild(guideText);
+
     // Create list
     const list = createElement('ul', {
         className: 'key-list'
@@ -661,6 +672,17 @@ export function renderPropertiesSection(container, totalItems, state) {
     summaryElement.appendChild(titleSpan);
     summaryElement.appendChild(countSpan);
     section.appendChild(summaryElement);
+
+    // Add guide text
+    const guideText = createElement('p', {
+        style: {
+            fontSize: '13px',
+            color: '#666',
+            margin: '8px 0 12px 0',
+            padding: '0 12px'
+        }
+    }, 'Click a property to assign selected references. Click the reference count to customize which references are assigned.');
+    section.appendChild(guideText);
 
     // Create list
     const list = createElement('ul', {

--- a/src/js/references/ui/display.js
+++ b/src/js/references/ui/display.js
@@ -727,6 +727,9 @@ export function renderPropertiesSection(container, totalItems, state) {
 function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignment) {
     const property = mappedKey.property;
 
+    // Check if this is a manual property that cannot accept references
+    const cannotAcceptReferences = ['label', 'description', 'alias'].includes(property.id);
+
     // Get current reference count for this property
     const assignedReferences = state ? state.getPropertyReferences(property.id) : [];
 
@@ -754,8 +757,8 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
     // Create list item
     const listItem = createElement('li', {
         style: {
-            opacity: '1',
-            cursor: 'pointer'
+            opacity: cannotAcceptReferences ? '0.6' : '1',
+            cursor: cannotAcceptReferences ? 'default' : 'pointer'
         }
     });
 
@@ -845,14 +848,14 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
         style: {
             fontSize: '0.85em',
             fontWeight: '500',
-            color: referenceCount > 0 ? '#2ecc71' : '#95a5a6',
-            cursor: 'pointer',
+            color: cannotAcceptReferences ? '#95a5a6' : (referenceCount > 0 ? '#2ecc71' : '#95a5a6'),
+            cursor: cannotAcceptReferences ? 'default' : 'pointer',
             userSelect: 'none'
         }
-    }, referenceCount > 0 ? referenceCountText : 'No references');
+    }, cannotAcceptReferences ? 'No references' : (referenceCount > 0 ? referenceCountText : 'No references'));
 
-    // Add click handler to reference count to open modal
-    if (state) {
+    // Add click handler to reference count to open modal (only if references are allowed)
+    if (state && !cannotAcceptReferences) {
         referenceCountSpan.addEventListener('click', (e) => {
             e.stopPropagation(); // Prevent list item click
             openPropertyReferenceModal(
@@ -879,8 +882,8 @@ function createPropertyListItem(mappedKey, totalItems, state, onReferenceAssignm
 
     listItem.appendChild(keyItemCompact);
 
-    // Add click handler for quick-assign (clicking anywhere on list item)
-    if (state) {
+    // Add click handler for quick-assign (clicking anywhere on list item) - only if references are allowed
+    if (state && !cannotAcceptReferences) {
         listItem.addEventListener('click', () => {
             // Get currently selected reference types
             const selectedReferenceTypes = state.getSelectedReferenceTypes();


### PR DESCRIPTION
## Summary
- Fixed duplicate references appearing in property modal when editing
- Improved UX with guide text explaining reference functionality
- Enhanced reference assignment workflow
- Disabled references for label, description, and aliases (not supported by Wikidata)
- Pre-fill URL fields with `https://` for convenience
- Display QID for linked items in reference modals

## Changes
- Fix duplicate references in property modal when editing custom references
- Show QID for reconciled items instead of "New item X" in Step 4 modals
- Allow removing all references by deselecting all and clicking a property
- Add guide text to "Available References" and "Properties" sections
- Pre-fill URL fields with `https://` in add custom reference modal
- Disable reference assignment for label, description, and aliases properties
- Display "No reference accepted" for properties that cannot have references

## Test plan
- [ ] Verify no duplicate references appear when editing
- [ ] Check that linked items show QID in reference modals
- [ ] Test removing all references by deselecting all references and clicking property
- [ ] Verify guide text appears and is helpful
- [ ] Check that URL fields are pre-filled with `https://`
- [ ] Confirm label, description, and aliases show "No reference accepted"
- [ ] Verify these properties cannot be clicked to assign references

🤖 Generated with [Claude Code](https://claude.com/claude-code)