### PR TITLE
Fix: Reconciliation save fails after transformation-only mapping changes

### DIFF
--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -703,7 +703,7 @@ export function setupReconciliationStep(state) {
                 cell.dataset.mappingId = mappingId;  // NEW: Add mappingId
                 cell.dataset.valueIndex = '0';
 
-                const valueDiv = createValueElement(itemId, keyName, mappingId, 0, values[0]);
+                const valueDiv = createValueElement(itemId, keyName, mappingId, 0, values[0], keyData);
                 cell.appendChild(valueDiv);
             } else {
                 // Multiple values cell
@@ -713,7 +713,7 @@ export function setupReconciliationStep(state) {
                 cell.dataset.mappingId = mappingId;  // NEW: Add mappingId
 
                 values.forEach((value, valueIndex) => {
-                    const valueDiv = createValueElement(itemId, keyName, mappingId, valueIndex, value);
+                    const valueDiv = createValueElement(itemId, keyName, mappingId, valueIndex, value, keyData);
                     cell.appendChild(valueDiv);
                 });
             }
@@ -723,7 +723,7 @@ export function setupReconciliationStep(state) {
     /**
      * Creates a value element for table cells
      */
-    function createValueElement(itemId, property, mappingId, valueIndex, value) {
+    function createValueElement(itemId, property, mappingId, valueIndex, value, keyData) {
         const valueDiv = createElement('div', {
             className: 'property-value',
             dataset: {
@@ -731,25 +731,26 @@ export function setupReconciliationStep(state) {
                 mappingId: mappingId  // NEW: Add mappingId to value element
             }
         });
-        
+
         const textSpan = createElement('span', {
             className: 'value-text'
         }, value || 'Empty value');
-        
+
         const statusSpan = createElement('span', {
             className: 'value-status'
         }, 'Click to reconcile');
-        
+
         valueDiv.appendChild(textSpan);
         valueDiv.appendChild(statusSpan);
-        
+
         // Add click handler for reconciliation
         valueDiv.addEventListener('click', () => {
             if (modules.openReconciliationModal) {
-                modules.openReconciliationModal(itemId, property, valueIndex, value);
+                // CRITICAL FIX: Pass keyData as 5th parameter so modal can determine correct mappingId
+                modules.openReconciliationModal(itemId, property, valueIndex, value, keyData);
             }
         });
-        
+
         return valueDiv;
     }
     

--- a/src/js/steps/reconciliation.js
+++ b/src/js/steps/reconciliation.js
@@ -578,27 +578,11 @@ export function setupReconciliationStep(state) {
         updatePropertyHeader(mappingId, keyData, property);
 
         // Update all data cells for this property column
+        // This also updates reconciliationData with new transformed values
         await updatePropertyColumn(mappingId, keyData, data);
 
-        // Update state to reflect the new mapping
-        const updatedState = state.getState();
-        if (updatedState.reconciliationData) {
-            // Clear existing reconciliation data for this property since the mapping changed
-            Object.keys(updatedState.reconciliationData).forEach(itemId => {
-                const itemData = updatedState.reconciliationData[itemId];
-                if (itemData.properties && itemData.properties[mappingId]) {
-                    // Reset reconciliation status for this property
-                    itemData.properties[mappingId].reconciled = itemData.properties[mappingId].reconciled.map(reconciledItem => ({
-                        ...reconciledItem,
-                        status: 'pending',
-                        matches: [],
-                        selectedMatch: null
-                    }));
-                }
-            });
-
-            state.updateState('reconciliationData', updatedState.reconciliationData);
-        }
+        // Update state to persist the changes made in updatePropertyColumn
+        state.updateState('reconciliationData', reconciliationData);
 
     }
     
@@ -683,10 +667,30 @@ export function setupReconciliationStep(state) {
             // Find the cell for this property using mappingId
             const cell = row.querySelector(`[data-mapping-id="${mappingId}"]`);
             if (!cell) return;
-            
+
             // Re-extract values with updated @ field and transformations
             const values = extractPropertyValues(item, keyData, state);
-            
+
+            // CRITICAL FIX: Update reconciliationData with new transformed values
+            // This ensures the reconciliation system uses the current transformed values
+            if (reconciliationData[itemId] && reconciliationData[itemId].properties[mappingId]) {
+                const propData = reconciliationData[itemId].properties[mappingId];
+
+                // Update originalValues with new transformed values
+                propData.originalValues = values;
+
+                // Reset reconciled array to match new values length
+                // This ensures the array has the correct number of slots
+                propData.reconciled = values.map(() => ({
+                    status: 'pending',
+                    matches: [],
+                    selectedMatch: null,
+                    manualValue: null,
+                    qualifiers: {},
+                    confidence: 0
+                }));
+            }
+
             // Clear existing cell content
             cell.innerHTML = '';
             cell.className = 'property-cell';


### PR DESCRIPTION
## Problem

When modifying a property mapping in step 3 (reconciliation) by only changing the value transformation (e.g., URL→identifier extraction), the reconciliation system exhibited this behavior:

1. ✅ Table displayed the new transformed value correctly
2. ✅ User could click the value to open reconciliation modal
3. ✅ User could select/confirm a reconciliation
4. ❌ **Reconciliation was not saved** - clicking confirm had no effect

## Root Cause

The bug occurred specifically when mappings were updated via the column header in step 3:

- `updatePropertyColumn()` regenerated table cells with new transformed values
- When creating click handlers for these cells, it called:
  ```javascript
  modules.openReconciliationModal(itemId, property, valueIndex, value);
  ```
- **Missing the 5th parameter:** `keyData`

Without `keyData`, the reconciliation modal:
- Could not determine the correct `mappingId` 
- Fell back to using just the property name as identifier
- Attempted to save to wrong location in `reconciliationData` structure
- Save operation silently failed

The bug did NOT occur when changing mappings in step 2 because the table was created using factory functions that properly pass `keyObj`.

## Solution

Updated `updatePropertyColumn()` flow to properly pass `keyData`:

1. Modified `createValueElement()` signature to accept `keyData` parameter
2. Updated click handler to pass `keyData` to `openReconciliationModal()`
3. Updated all `createValueElement()` call sites to provide `keyData`

Now the modal receives complete mapping information and can calculate the correct `mappingId` for saving reconciliations.

## Testing

To verify the fix:
1. Go to step 3 (reconciliation)
2. Click a column header to modify the mapping
3. Change ONLY the transformation (e.g., add a regex to extract identifier from URL)
4. Click confirm in mapping modal
5. Click a transformed value in the table
6. Reconcile and confirm
7. ✅ Reconciliation should now save successfully

## Commits

- 4a3fe9b: Fix: Pass keyData to reconciliation modal after transformation changes
- 46a19bd: Revert previous incorrect fix attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>