### PR TITLE
Add GitHub fork ribbon to top right corner

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,11 @@
 </head>
 <body>
     <a class="github-fork-ribbon" href="https://github.com/MaastrichtU-Library/omekas-to-wikidata/tree/main" data-ribbon="View on GitHub" title="View on GitHub">View on GitHub</a>
-    <style>.github-fork-ribbon:before { background-color: #333; }</style>
+    <a class="github-fork-ribbon left-top" href="https://www.wikidata.org/wiki/Wikidata:WikiProject_Open_Topstukken_Maastricht_University_and_Radboud_University" data-ribbon="Wiki Documentation" title="Wiki Documentation">Wiki Documentation</a>
+    <style>
+        .github-fork-ribbon:before { background-color: #333; }
+        .github-fork-ribbon.left-top:before { background-color: #006699; }
+    </style>
 
     <div class="container">
         <header>

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,12 @@
     <title>Omeka S to Wikidata</title>
     <link rel="icon" type="image/x-icon" href="../favicon.ico">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
 </head>
 <body>
+    <a class="github-fork-ribbon" href="https://github.com/MaastrichtU-Library/omekas-to-wikidata/tree/main" data-ribbon="View on GitHub" title="View on GitHub">View on GitHub</a>
+    <style>.github-fork-ribbon:before { background-color: #333; }</style>
+
     <div class="container">
         <header>
             <div class="header-content">


### PR DESCRIPTION
## Summary
- Added GitHub fork ribbon to top right corner of application
- Links to project repository on GitHub

## Changes
- Added github-fork-ribbon CSS library from CDN
- Added ribbon element linking to https://github.com/MaastrichtU-Library/omekas-to-wikidata/tree/main
- Custom dark gray (#333) styling for ribbon background

🤖 Generated with [Claude Code](https://claude.com/claude-code)