### PR TITLE
Fix: Include keys with null propertyId identifiers in mapping interface

### DIFF
--- a/src/js/mapping/ui/mapping-lists.js
+++ b/src/js/mapping/ui/mapping-lists.js
@@ -108,14 +108,16 @@ export async function populateLists(state) {
     if (identifierFields.length > 0) {
         try {
             const mappingPromises = identifierFields.map(async (keyObj) => {
-                // Skip identifiers without a known property ID
+                // Add identifiers without a known property ID to non-linked keys
+                // These include Wikidata entities and ISO language codes that need manual mapping
                 if (keyObj.identifierInfo.propertyId === null) {
                     console.info(
-                        `Skipping identifier field '${keyObj.key}': ` +
+                        `Adding identifier field '${keyObj.key}' to non-linked keys: ` +
                         `Detected as ${keyObj.identifierInfo.type} (${keyObj.identifierInfo.label}) ` +
-                        `but no property mapping is available. ` +
+                        `but no automatic property mapping is available. ` +
                         `Sample value: ${JSON.stringify(keyObj.sampleValue)}`
                     );
+                    keysToAddAsNonLinked.push(keyObj);
                     return null;
                 }
 


### PR DESCRIPTION
## Summary
- Fixes missing keys in the mapping interface that contain identifiers with no automatic property mapping
- Three keys (`schema:inLanguage`, `schema:keywords`, `schema:provider`) were being silently dropped
- These keys now properly appear in the non-linked keys list for manual mapping

## Problem
The mapping interface was showing only 24 keys instead of the actual 27 keys present in the JSON data. Investigation revealed that keys containing certain identifier types (Wikidata entities, ISO language codes) with `propertyId: null` were being completely dropped during processing.

## Root Cause
In `src/js/mapping/ui/mapping-lists.js`, when processing identifier fields, keys with `propertyId: null` were skipped with a `console.info` message but never added to any category (non-linked, mapped, or ignored). This caused them to disappear from the UI entirely.

## Solution
Modified the identifier processing logic to add these keys to the non-linked keys list instead of skipping them. This allows users to manually map these properties since no automatic mapping is available.

## Changes
- **Modified**: `src/js/mapping/ui/mapping-lists.js:111-120`
  - Changed from returning `null` (skip) to calling `keysToAddAsNonLinked.push(keyObj)`
  - Updated log message to clarify the key is being added to non-linked keys

## Testing
- Verified with real-world JSON data containing all three missing key types
- Confirmed all 27 keys now appear in the correct categories
- Keys with `propertyId: null` properly show up in non-linked keys for manual mapping

## Impact
- **Before**: 7 non-linked keys (missing 3)
- **After**: 10 non-linked keys (all present)
- No changes to mapped or ignored key counts
- Total key count: 27 (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)